### PR TITLE
Replace conn master host > instance host

### DIFF
--- a/builder/xenserver/common/step_type_boot_command.go
+++ b/builder/xenserver/common/step_type_boot_command.go
@@ -68,14 +68,13 @@ func (self *StepTypeBootCommand) Run(ctx context.Context, state multistep.StateB
 	}
 
 	location, err := c.client.Console.GetLocation(c.session, consoles[0])
-	ui.Say(fmt.Sprintf("LOCATION: %s", location))
 	if err != nil {
 		ui.Error(err.Error())
 		return multistep.ActionHalt
 	}
 	locationPieces := strings.SplitAfter(location, "/")
 	consoleHost := strings.TrimSuffix(locationPieces[2], "/")
-	ui.Say("Connecting to the VM console VNC over xapi")
+	ui.Say(fmt.Sprintf("Connecting to the VM console VNC over xapi via %s", consoleHost))
 	conn, err := net.Dial("tcp", fmt.Sprintf("%s:443", consoleHost))
 
 	if err != nil {

--- a/builder/xenserver/common/step_type_boot_command.go
+++ b/builder/xenserver/common/step_type_boot_command.go
@@ -91,7 +91,6 @@ func (self *StepTypeBootCommand) Run(ctx context.Context, state multistep.StateB
 	}
 	tlsConn := tls.Client(conn, tlsConfig)
 
-	ui.Say(fmt.Sprintf("%s", strings.TrimSuffix(locationPieces[2], "/")))
 	consoleLocation := strings.TrimSpace(fmt.Sprintf("/%s", locationPieces[len(locationPieces)-1]))
 	httpReq := fmt.Sprintf("CONNECT %s HTTP/1.0\r\nHost: %s\r\nCookie: session_id=%s\r\n\r\n", consoleLocation, consoleHost, c.session)
 	fmt.Printf("Sending the follow http req: %v", httpReq)


### PR DESCRIPTION
This is a bugfix for https://github.com/ddelnano/packer-plugin-xenserver/issues/12

Originally, this module connects to the cluster host master, instead of connecting to the host where the instance is. Ive tested it couple of times and it seems to be working.