### PR TITLE
Add documentation for the `network_names` configuration option

### DIFF
--- a/docs/builders/xenserver-iso.html.markdown
+++ b/docs/builders/xenserver-iso.html.markdown
@@ -124,7 +124,7 @@ each category, the available options are alphabetized and described.
   regardless of success. "on_success" requests that the VM only be cleaned up if an
   artifact was produced. The latter is useful for debugging templates that fail.
 
-* `network_names` (list) - A list of networks identified by their name label which 
+* `network_names` (array of strings) - A list of networks identified by their name label which 
   will be used for the VM during creation. The first network will correspond to the VM's
   first network interface (VIF), the second will corespond to the second VIF and so on.
 

--- a/docs/builders/xenserver-iso.html.markdown
+++ b/docs/builders/xenserver-iso.html.markdown
@@ -124,6 +124,10 @@ each category, the available options are alphabetized and described.
   regardless of success. "on_success" requests that the VM only be cleaned up if an
   artifact was produced. The latter is useful for debugging templates that fail.
 
+* `network_names` (list) - A list of networks identified by their name label which 
+  will be used for the VM during creation. The first network will correspond to the VM's
+  first network interface (VIF), the second will corespond to the second VIF and so on.
+
 * `output_directory` (string) - This is the path to the directory where the
   resulting virtual machine will be created. This may be relative or absolute.
   If relative, the path is relative to the working directory when `packer`


### PR DESCRIPTION
This addresses #16 and will make it more clear that users can instruct packer to use a specific set of networks when creating a VM