### PR TITLE
Ensure vm is cleaned up when build is interrupted on the wait for ip step

### DIFF
--- a/builder/xenserver/common/step_start_vm_paused.go
+++ b/builder/xenserver/common/step_start_vm_paused.go
@@ -3,13 +3,14 @@ package common
 import (
 	"context"
 	"fmt"
-	"log"
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	"github.com/hashicorp/packer-plugin-sdk/packer"
 )
 
-type StepStartVmPaused struct{}
+type StepStartVmPaused struct {
+	VmCleanup
+}
 
 func (self *StepStartVmPaused) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 
@@ -53,25 +54,4 @@ func (self *StepStartVmPaused) Run(ctx context.Context, state multistep.StateBag
 	state.Put("domid", domid)
 
 	return multistep.ActionContinue
-}
-
-func (self *StepStartVmPaused) Cleanup(state multistep.StateBag) {
-	config := state.Get("commonconfig").(CommonConfig)
-	c := state.Get("client").(*Connection)
-
-	if config.ShouldKeepVM(state) {
-		return
-	}
-
-	uuid := state.Get("instance_uuid").(string)
-	instance, err := c.client.VM.GetByUUID(c.session, uuid)
-	if err != nil {
-		log.Printf(fmt.Sprintf("Unable to get VM from UUID '%s': %s", uuid, err.Error()))
-		return
-	}
-
-	err = c.client.VM.HardShutdown(c.session, instance)
-	if err != nil {
-		log.Printf(fmt.Sprintf("Unable to force shutdown VM '%s': %s", uuid, err.Error()))
-	}
 }

--- a/builder/xenserver/common/step_wait_for_ip.go
+++ b/builder/xenserver/common/step_wait_for_ip.go
@@ -10,6 +10,7 @@ import (
 )
 
 type StepWaitForIP struct {
+	VmCleanup
 	Chan    <-chan string
 	Timeout time.Duration
 }
@@ -83,8 +84,6 @@ func (self *StepWaitForIP) Run(ctx context.Context, state multistep.StateBag) mu
 
 	return multistep.ActionContinue
 }
-
-func (self *StepWaitForIP) Cleanup(state multistep.StateBag) {}
 
 func InstanceSSHIP(state multistep.StateBag) (string, error) {
 	ip := state.Get("instance_ssh_address").(string)

--- a/builder/xenserver/common/vm_cleanup.go
+++ b/builder/xenserver/common/vm_cleanup.go
@@ -1,0 +1,31 @@
+package common
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+)
+
+type VmCleanup struct{}
+
+func (self *VmCleanup) Cleanup(state multistep.StateBag) {
+	config := state.Get("commonconfig").(CommonConfig)
+	c := state.Get("client").(*Connection)
+
+	if config.ShouldKeepVM(state) {
+		return
+	}
+
+	uuid := state.Get("instance_uuid").(string)
+	instance, err := c.client.VM.GetByUUID(c.session, uuid)
+	if err != nil {
+		log.Printf(fmt.Sprintf("Unable to get VM from UUID '%s': %s", uuid, err.Error()))
+		return
+	}
+
+	err = c.client.VM.HardShutdown(c.session, instance)
+	if err != nil {
+		log.Printf(fmt.Sprintf("Unable to force shutdown VM '%s': %s", uuid, err.Error()))
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/xenserver/packer-builder-xenserver
 
-go 1.14
+go 1.16
 
 require (
 	github.com/amfranz/go-xmlrpc-client v0.0.0-20190612172737-76858463955d


### PR DESCRIPTION
This addresses #11.

## Testing
- [x] Pressed Ctrl-C while packer was on it's wait for Ip step and verified that the VM was deleted
```
ddelnano@ddelnano-desktop:~/go/src/github.com/xenserver/packer-builder-xenserver$  packer1.7 build  -debug  -
-var sr_name='Local storage' --var sr_iso_name=LocalISO examples/centos8.json
Debug mode enabled. Builds will not be parallelized.
xenserver-iso: output will be in this color.

==> xenserver-iso: XAPI client session established
==> xenserver-iso: Starting HTTP server on port 8000
==> xenserver-iso: Step: Create Instance
==> xenserver-iso: Using the following SR for the VM: OpaqueRef:10e7e21a-0569-4e6c-931e-d295a76a3be0
==> xenserver-iso: Created instance '8e9ae543-e7fb-0326-256b-6f9df5708377'
==> xenserver-iso: Step: Start VM Paused
==> xenserver-iso: Step: Set SSH address to VM host IP
==> xenserver-iso: Set host SSH address to '192.168.88.89'.
==> xenserver-iso: Unpausing VM 8e9ae543-e7fb-0326-256b-6f9df5708377
==> xenserver-iso: Waiting 10s for boot...
==> xenserver-iso: Connecting to the VM console VNC over xapi via 192.168.88.89
==> xenserver-iso: Making HTTP request to initiate VNC connection: CONNECT /console?uuid=e1d12874-504f-94c7-f028-f5de25f8d2e9 HTTP/1.0
==> xenserver-iso: Host: 192.168.88.89
==> xenserver-iso: Cookie: session_id=OpaqueRef:5c68fe3b-3277-41b8-9089-fd5616e5c126
==> xenserver-iso:
==> xenserver-iso:
==> xenserver-iso: Received response: HTTP/1.1 200 OK
==> xenserver-iso: Connection: keep-alive
==> xenserver-iso: Cache-Control: no-cache, no-store
==> xenserver-iso:
==> xenserver-iso:
    xenserver-iso: Found local IP: 192.168.88.254
==> xenserver-iso: Typing boot commands over VNC...
==> xenserver-iso: Finished typing.
==> xenserver-iso: Step: Wait for VM's IP to become known to us.
Cancelling build after receiving interrupt
==> xenserver-iso: Could not get IP address of VM: Interrupted
==> xenserver-iso: Destroying VM
==> xenserver-iso: Destroying VDI
==> xenserver-iso: Deleting output directory...
Build 'xenserver-iso' errored after 44 seconds 985 milliseconds: Build was cancelled.

==> Wait completed after 44 seconds 985 milliseconds
Cleanly cancelled builds after being interrupted.
```