### PR TITLE
More reliable cloud-init startup

### DIFF
--- a/builder/xenserver/iso/builder.go
+++ b/builder/xenserver/iso/builder.go
@@ -191,6 +191,7 @@ func (self *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (p
 		},
 		&commonsteps.StepCreateFloppy{
 			Files: self.config.FloppyFiles,
+			Label: "cidata",
 		},
 		&xscommon.StepHTTPServer{
 			Chan: httpReqChan,

--- a/examples/http/ubuntu-2004/user-data
+++ b/examples/http/ubuntu-2004/user-data
@@ -15,6 +15,8 @@ autoinstall:
     # This is the crypted pass of 'ubuntu'
     password: "$6$exDY1mhS4KUYCE/2$zmn9ToZwTKLhCw.b4/b.ZRTIZM30JZ4QrOQ2aOXJ8yk96xpcCof0kxKwuX1kqLG/ygbJ1f8wxED22bTL4F46P0"
     username: testuser
+  packages:
+    - xe-guest-utilities
   ssh:
     install-server: yes
     allow-pw: yes

--- a/examples/http/ubuntu-2004/user-data
+++ b/examples/http/ubuntu-2004/user-data
@@ -1,4 +1,13 @@
 #cloud-config
+
+# hack for cloud-init per:
+# https://github.com/leakespeake/packer/blob/3f3e361751b4be9326b66771d96f2519bc8f885e/builders/vmware/vsphere-iso/ubuntu-server-20-04/hcl2/http/ubuntu-server-subiquity/user-data
+runcmd:
+  # to enable true auto-install for Ubuntu 20.04 with cloud-init nocloud (eliminates "Continue with autoinstall?" prompt)
+  - [eval, 'echo $(cat /proc/cmdline) "autoinstall" > /root/cmdline']
+  - [eval, 'mount -n --bind -o ro /root/cmdline /proc/cmdline']
+  - [eval, 'snap restart subiquity.subiquity-service']
+
 autoinstall:
   version: 1
   identity:

--- a/examples/ubuntu/ubuntu-2004.pkr.hcl
+++ b/examples/ubuntu/ubuntu-2004.pkr.hcl
@@ -65,12 +65,10 @@ source "xenserver-iso" "ubuntu-2004" {
   vm_memory      = 4096
   disk_size      = 20000
 
-  http_directory = "examples/http/ubuntu-2004"
-  boot_command   = [
-    "<esc><f6> autoinstall ds=nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/<enter><wait>",
-    "<f6><wait><esc><wait> autoinstall ds=nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/<enter><wait>"
+  floppy_files = [
+    "examples/http/ubuntu-2004/meta-data",
+    "examples/http/ubuntu-2004/user-data",
   ]
-  boot_wait      = "10s"
 
   ssh_username            = "testuser"
   ssh_password            = "ubuntu"


### PR DESCRIPTION
Rather than try to catch grub via VNC before it moves on, we can use the floppy_files mount to provide cloud-config by setting its volume label to `cidata`. This requires a hack in the cloud-config to prevent autoinstall from hanging at a prompt, but I think this is a fair trade for getting successful builds every time.