### PR TITLE
Fix XenServer tools guest IP address resolution

### DIFF
--- a/builder/xenserver/common/step_wait_for_ip.go
+++ b/builder/xenserver/common/step_wait_for_ip.go
@@ -60,7 +60,8 @@ func (self *StepWaitForIP) Run(ctx context.Context, state multistep.StateBag) mu
 						return false, err
 					}
 					networks := metrics.Networks
-					if ip, ok := networks["0/ip"]; ok {
+					var ok bool
+					if ip, ok = networks["0/ip"]; ok {
 						if ip != "" {
 							ui.Message(fmt.Sprintf("Got IP '%s' from XenServer tools", ip))
 							return true, nil


### PR DESCRIPTION
There seems to be some kind of scope mismatch here as the IP is correctly retrieved but seems to have been stashed in a shadowed variable. Here's a screencap of the issue in action:
![image](https://user-images.githubusercontent.com/1565435/146115418-5b3dbfef-b15c-4ed5-8ae1-cdd504914c61.png)
Note that the IP is correct at ` Got IP '192.168.207.159' from XenServer tools` but then blank in `Got IP address ''`. This results in the connection never completing.

Here's a screencap after my patch showing the IP address shows in both log lines and the connection is established:
![image](https://user-images.githubusercontent.com/1565435/146115617-878dadac-5755-4c3c-a723-d05609d726c6.png)
