### PR TITLE
feat: Make firmware configurable

### DIFF
--- a/builder/xenserver/common/config.go
+++ b/builder/xenserver/common/config.go
@@ -33,6 +33,8 @@ type Config struct {
 	InstallTimeout    time.Duration ``
 	SourcePath        string        `mapstructure:"source_path"`
 
+	Firmware string `mapstructure:"firmware"`
+
 	ctx interpolate.Context
 }
 

--- a/builder/xenserver/common/config.hcl2spec.go
+++ b/builder/xenserver/common/config.hcl2spec.go
@@ -107,6 +107,7 @@ type FlatConfig struct {
 	PlatformArgs              map[string]string `mapstructure:"platform_args" cty:"platform_args" hcl:"platform_args"`
 	RawInstallTimeout         *string           `mapstructure:"install_timeout" cty:"install_timeout" hcl:"install_timeout"`
 	SourcePath                *string           `mapstructure:"source_path" cty:"source_path" hcl:"source_path"`
+	Firmware                  *string           `mapstructure:"firmware" cty:"firmware" hcl:"firmware"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -218,6 +219,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"platform_args":                &hcldec.AttrSpec{Name: "platform_args", Type: cty.Map(cty.String), Required: false},
 		"install_timeout":              &hcldec.AttrSpec{Name: "install_timeout", Type: cty.String, Required: false},
 		"source_path":                  &hcldec.AttrSpec{Name: "source_path", Type: cty.String, Required: false},
+		"firmware":                     &hcldec.AttrSpec{Name: "firmware", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/builder/xenserver/common/step_start_vm_paused.go
+++ b/builder/xenserver/common/step_start_vm_paused.go
@@ -16,6 +16,7 @@ func (self *StepStartVmPaused) Run(ctx context.Context, state multistep.StateBag
 
 	c := state.Get("client").(*Connection)
 	ui := state.Get("ui").(packer.Ui)
+	config := state.Get("config").(Config)
 
 	ui.Say("Step: Start VM Paused")
 
@@ -34,7 +35,7 @@ func (self *StepStartVmPaused) Run(ctx context.Context, state multistep.StateBag
 		return multistep.ActionHalt
 	}
 
-	err = c.client.VM.SetHVMBootParams(c.session, instance, map[string]string{"order": "cd"})
+	err = c.client.VM.SetHVMBootParams(c.session, instance, map[string]string{"order": "cd", "firmware": config.Firmware})
 	if err != nil {
 		ui.Error(fmt.Sprintf("Unable to set HVM boot params: %s", err.Error()))
 		return multistep.ActionHalt

--- a/builder/xenserver/iso/builder.go
+++ b/builder/xenserver/iso/builder.go
@@ -77,6 +77,10 @@ func (self *Builder) Prepare(raws ...interface{}) (params []string, warns []stri
 		self.config.CloneTemplate = "Other install media"
 	}
 
+	if self.config.Firmware == "" {
+		self.config.Firmware = "bios"
+	}
+
 	if len(self.config.PlatformArgs) == 0 {
 		pargs := make(map[string]string)
 		pargs["viridian"] = "false"


### PR DESCRIPTION
I extracted the changes as-is from https://github.com/ddelnano/packer-plugin-xenserver/pull/28.

I needed to set the firmware to `uefi` because `bios` was not working properly when trying the build an Ubuntu 20.04 image. I had some weird issues when booting because `xenbus_probe_frontend` was timing out while waiting for devices to initialize. When using `uefi`, I don't have this problem and the Packer build completes in around 15 minutes instead of 27 minutes.

I'm not well-versed in Go, so let me know if something is missing such as tests or if you need more information from me.

I tested locally using:

```bash
go build -o packer-plugin-xenserver

chmod +x packer-plugin-xenserver

mv packer-plugin-xenserver \
  /usr/local/bin/github.com/ddelnano/xenserver/packer-plugin-xenserver_v0.4.0_x5.0_darwin_amd64

sha256sum /usr/local/bin/github.com/ddelnano/xenserver/packer-plugin-xenserver_v0.4.0_x5.0_darwin_amd64 \
  > /usr/local/bin/github.com/ddelnano/xenserver/packer-plugin-xenserver_v0.4.0_x5.0_darwin_amd64_SHA256SUM
```

Then in the folder with my Packer file:

```bash
packer init .
packer build .
```