### PR TITLE
Fix ISO SR config 

### DIFF
--- a/builder/xenserver/common/common_config.go
+++ b/builder/xenserver/common/common_config.go
@@ -271,7 +271,7 @@ func (config CommonConfig) GetISOSR(c *Connection) (xenapi.SRRef, error) {
 
 	} else {
 		// Use the provided name label to find the SR to use
-		srs, err := c.GetClient().SR.GetByNameLabel(c.session, config.SrName)
+		srs, err := c.GetClient().SR.GetByNameLabel(c.session, config.SrISOName)
 
 		if err != nil {
 			return srRef, err
@@ -279,9 +279,9 @@ func (config CommonConfig) GetISOSR(c *Connection) (xenapi.SRRef, error) {
 
 		switch {
 		case len(srs) == 0:
-			return srRef, fmt.Errorf("Couldn't find a SR with the specified name-label '%s'", config.SrName)
+			return srRef, fmt.Errorf("Couldn't find a SR with the specified name-label '%s'", config.SrISOName)
 		case len(srs) > 1:
-			return srRef, fmt.Errorf("Found more than one SR with the name '%s'. The name must be unique", config.SrName)
+			return srRef, fmt.Errorf("Found more than one SR with the name '%s'. The name must be unique", config.SrISOName)
 		}
 
 		return srs[0], nil


### PR DESCRIPTION
The `GetISOSR` function was using `config.SrName` instead of `config.ISOSrName` to look up the ISO SR, resulting in using the wrong SR. In addition to fixing this bug, I've also made the `sr_iso_name` config optional (defaulting to the default SR for the pool).

To get the pool default SR, I've had to work around a compatibility issue with newer XenAPI version in go-xen-api-client. In particular, some values for the pool `allowed_operations` are not recognised, resulting in a parse error when retrieving pool records. The workaround is to work with pool refs instead of pool records.