### PR TITLE
Remove iso checksum type and fix tests

### DIFF
--- a/builder/xenserver/iso/builder.go
+++ b/builder/xenserver/iso/builder.go
@@ -40,7 +40,7 @@ func (self *Builder) Prepare(raws ...interface{}) (params []string, warns []stri
 	}, raws...)
 
 	if err != nil {
-		packer.MultiErrorAppend(errs, err)
+		errs = packer.MultiErrorAppend(errs, err)
 	}
 
 	errs = packer.MultiErrorAppend(

--- a/builder/xenserver/iso/builder_test.go
+++ b/builder/xenserver/iso/builder_test.go
@@ -15,8 +15,7 @@ func testConfig() map[string]interface{} {
 		"remote_username":   "admin",
 		"remote_password":   "admin",
 		"vm_name":           "foo",
-		"iso_checksum":      "foo",
-		"iso_checksum_type": "md5",
+		"iso_checksum":      "md5:A221725EE181A44C67E25BD6A2516742",
 		"iso_url":           "http://www.google.com/",
 		"shutdown_command":  "yes",
 		"ssh_username":      "foo",
@@ -181,9 +180,20 @@ func TestBuilderPrepare_ISOChecksum(t *testing.T) {
 	var b Builder
 	config := testConfig()
 
+	// Test good
+
+	b = Builder{}
+	_, warns, err := b.Prepare(config)
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+
 	// Test bad
 	config["iso_checksum"] = ""
-	_, warns, err := b.Prepare(config)
+	_, warns, err = b.Prepare(config)
 	if len(warns) > 0 {
 		t.Fatalf("bad: %#v", warns)
 	}
@@ -191,80 +201,9 @@ func TestBuilderPrepare_ISOChecksum(t *testing.T) {
 		t.Fatal("should have error")
 	}
 
-	// Test good
-	config["iso_checksum"] = "FOo"
-	b = Builder{}
-	_, warns, err = b.Prepare(config)
-	if len(warns) > 0 {
-		t.Fatalf("bad: %#v", warns)
-	}
-	if err != nil {
-		t.Fatalf("should not have error: %s", err)
-	}
 
-	if b.config.ISOChecksum != "foo" {
-		t.Fatalf("should've lowercased: %s", b.config.ISOChecksum)
-	}
 }
 
-func TestBuilderPrepare_ISOChecksumType(t *testing.T) {
-	var b Builder
-	config := testConfig()
-
-	// Test bad
-	config["iso_checksum_type"] = ""
-	_, warns, err := b.Prepare(config)
-	if len(warns) > 0 {
-		t.Fatalf("bad: %#v", warns)
-	}
-	if err == nil {
-		t.Fatal("should have error")
-	}
-
-	// Test good
-	config["iso_checksum_type"] = "mD5"
-	b = Builder{}
-	_, warns, err = b.Prepare(config)
-	if len(warns) > 0 {
-		t.Fatalf("bad: %#v", warns)
-	}
-	if err != nil {
-		t.Fatalf("should not have error: %s", err)
-	}
-
-	if b.config.ISOChecksumType != "md5" {
-		t.Fatalf("should've lowercased: %s", b.config.ISOChecksumType)
-	}
-
-	// Test unknown
-	config["iso_checksum_type"] = "fake"
-	b = Builder{}
-	_, warns, err = b.Prepare(config)
-	if len(warns) > 0 {
-		t.Fatalf("bad: %#v", warns)
-	}
-	if err == nil {
-		t.Fatal("should have error")
-	}
-
-	// Test none
-	config["iso_checksum_type"] = "none"
-	b = Builder{}
-	_, warns, err = b.Prepare(config)
-	// @todo: give warning in this case?
-	/*
-		if len(warns) == 0 {
-			t.Fatalf("bad: %#v", warns)
-		}
-	*/
-	if err != nil {
-		t.Fatalf("should not have error: %s", err)
-	}
-
-	if b.config.ISOChecksumType != "none" {
-		t.Fatalf("should've lowercased: %s", b.config.ISOChecksumType)
-	}
-}
 
 func TestBuilderPrepare_ISOUrl(t *testing.T) {
 	var b Builder

--- a/builder/xenserver/iso/builder_test.go
+++ b/builder/xenserver/iso/builder_test.go
@@ -5,7 +5,9 @@ import (
 	"testing"
 
 	"github.com/hashicorp/packer-plugin-sdk/packer"
+	"github.com/hashicorp/packer-plugin-sdk/common"
 )
+
 
 func testConfig() map[string]interface{} {
 	return map[string]interface{}{
@@ -19,7 +21,7 @@ func testConfig() map[string]interface{} {
 		"shutdown_command":  "yes",
 		"ssh_username":      "foo",
 
-		packer.BuildNameConfigKey: "foo",
+		common.BuildNameConfigKey: "foo",
 	}
 }
 

--- a/builder/xenserver/xva/builder.go
+++ b/builder/xenserver/xva/builder.go
@@ -38,7 +38,7 @@ func (self *Builder) Prepare(raws ...interface{}) (params []string, warns []stri
 	}, raws...)
 
 	if err != nil {
-		packer.MultiErrorAppend(errs, err)
+		errs = packer.MultiErrorAppend(errs, err)
 	}
 
 	errs = packer.MultiErrorAppend(

--- a/builder/xenserver/xva/builder_test.go
+++ b/builder/xenserver/xva/builder_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/packer-plugin-sdk/packer"
+	"github.com/hashicorp/packer-plugin-sdk/common"
 )
 
 func testConfig() map[string]interface{} {
@@ -16,7 +17,7 @@ func testConfig() map[string]interface{} {
 		"ssh_username":     "foo",
 		"source_path":      ".",
 
-		packer.BuildNameConfigKey: "foo",
+		common.BuildNameConfigKey: "foo",
 	}
 }
 

--- a/docs/builders/iso/xenserver-iso.html.markdown
+++ b/docs/builders/iso/xenserver-iso.html.markdown
@@ -29,14 +29,27 @@ each category, the available options are alphabetized and described.
 
 * `iso_checksum` (string) - The checksum for the OS ISO file. Because ISO
   files are so large, this is required and Packer will verify it prior
-  to booting a virtual machine with the ISO attached. The type of the
-  checksum is specified with `iso_checksum_type`, documented below.
+  to booting a virtual machine with the ISO attached. The type of
+  the checksum is specified within the checksum field as a prefix, ex:
+  "md5:{$checksum}". The type of the checksum can also be omitted and
+  Packer will try to infer it based on string length. Valid values are
+  "none", "{$checksum}", "md5:{$checksum}", "sha1:{$checksum}",
+  "sha256:{$checksum}", "sha512:{$checksum}" or "file:{$path}". Here is a
+  list of valid checksum values:
+   * md5:090992ba9fd140077b0661cb75f7ce13
+   * 090992ba9fd140077b0661cb75f7ce13
+   * sha1:ebfb681885ddf1234c18094a45bbeafd91467911
+   * ebfb681885ddf1234c18094a45bbeafd91467911
+   * sha256:ed363350696a726b7932db864dda019bd2017365c9e299627830f06954643f93
+   * ed363350696a726b7932db864dda019bd2017365c9e299627830f06954643f93
+   * file:http://releases.ubuntu.com/20.04/SHA256SUMS
+   * file:file://./local/path/file.sum
+   * file:./local/path/file.sum
+   * none
+  Although the checksum will not be verified when it is set to "none",
+  this is not recommended since these files can be very large and
+  corruption does happen from time to time.
 
-* `iso_checksum_type` (string) - The type of the checksum specified in
-  `iso_checksum`. Valid values are "none", "md5", "sha1", "sha256", or
-  "sha512" currently. While "none" will skip checksumming, this is not
-  recommended since ISO files are generally large and corruption does happen
-  from time to time.
 
 * `iso_url` (string) - A URL to the ISO containing the installation image.
   This URL can be either an HTTP URL or a file URL (or path to a file).


### PR DESCRIPTION
Remove iso_checksum_type checks

This aligns the Xenserver plugin to being a bit more inline with what Packer > 1.6.0 is expecting, since packer now simply ignores the iso_checksum_type (it's supposed to error out but that code path isn't working right now because we don't set PluginType in the configs. The unit tests have been altered to reflect this reality.

Note that this isn't a comprehensive change; the config still has the inert ISOChecksumType, and there's probably a laundry list of other things that needs to be looked at, For now though, we have working unit tests again.

Documentation has been updated to reflect this new change as well. 