### PR TITLE
Fix cloudinit ready template generation

### DIFF
--- a/builder/xenserver/iso/step_create_instance.go
+++ b/builder/xenserver/iso/step_create_instance.go
@@ -101,6 +101,12 @@ func (self *stepCreateInstance) Run(ctx context.Context, state multistep.StateBa
 		}
 	}
 
+	err = c.GetClient().VM.RemoveFromOtherConfig(c.GetSessionRef(), instance, "disks")
+	if err != nil {
+		ui.Error(fmt.Sprintf("Error removing disks from VM other-config: %s", err.Error()))
+		return multistep.ActionHalt
+	}
+
 	// Create VDI for the instance
 	sr, err := config.GetSR(c)
 


### PR DESCRIPTION
Adds a line of code that should fix the issues decribed here on the [XCP-NG Forum](https://xcp-ng.org/forum/topic/6795/xo-packer-template-disk-issues/10)

The following fix calls the xapi `VM.remove_from_other_config` hook to remove any "disks" entries from the vm that will be turned into a template via Packer. Currently this fix has only been tested with the Xen Orchestra "Ubuntu Focal Fossa 20.04" default template.