### PR TITLE
Update the ubuntu example to be resilient to ISO releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If you are using an older version of packer or are still using json templates yo
 ## Developing the builder
 
 ### Dependencies
-* Packer >= v1.8.x (https://packer.io)
+* Packer >= v1.7.1 (https://packer.io)
 * XenServer / Citrix Hypervisor > 7.6
 * Golang 1.16
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If you are using an older version of packer or are still using json templates yo
 ## Developing the builder
 
 ### Dependencies
-* Packer >= v1.7.1 (https://packer.io)
+* Packer >= v1.8.x (https://packer.io)
 * XenServer / Citrix Hypervisor > 7.6
 * Golang 1.16
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,7 +7,8 @@ In order to see an exhaustive list of configuration options for the packer build
 ### Running the examples
 
 In order to run the examples you will need to perform the following steps:
-1. Export those vars:
+1. Install packer 1.8 or later (the Ubuntu example requires the `http` data source)
+2. Export those vars:
 ```
 PKR_VAR_remote_host
 PKR_VAR_remote_password
@@ -17,9 +18,9 @@ PKR_VAR_sr_iso_name
 ``` 
 `PKR_VAR_remote_host` must be the resource pool primary, aka the master.
 
-2. Run `packer init path/to/defenition.pkr.hcl` to download the xenserver plugin
+3. Run `packer init path/to/defenition.pkr.hcl` to download the xenserver plugin
 
-2. Run `packer build  path/to/defenition.pkr.hcl`   
+4. Run `packer build  path/to/defenition.pkr.hcl`   
 so for example:
 `packer build  examples/centos/centos8-netinstall.pkr.hcl`
 

--- a/examples/ubuntu/ubuntu-2004.pkr.hcl
+++ b/examples/ubuntu/ubuntu-2004.pkr.hcl
@@ -7,6 +7,25 @@ packer {
   }
 }
 
+# This local determines what Ubuntu iso URL and sha256 hash we lookup. Updating
+# this will allow a new version to be pulled in.
+local "ubuntu_version" {
+  expression = "22.04"
+}
+
+
+data "http" "ubuntu_sha_and_release" {
+  url = "https://releases.ubuntu.com/22.04/SHA256SUMS"
+}
+
+local "ubuntu_sha256" {
+  expression = regex("([A-Za-z0-9]+)[\\s\\*]+ubuntu-.*server", data.http.ubuntu_sha_and_release.body)
+}
+
+local "ubuntu_url_path" {
+  expression = regex("[A-Za-z0-9]+[\\s\\*]+ubuntu-${local.ubuntu_version}.(\\d+)-live-server-amd64.iso", data.http.ubuntu_sha_and_release.body)
+}
+
 variable "remote_host" {
   type        = string
   description = "The ip or fqdn of your XenServer. This will be pulled from the env var 'PKR_VAR_XAPI_HOST'"
@@ -48,9 +67,9 @@ locals {
 
 
 source "xenserver-iso" "ubuntu-2004" {
-  iso_checksum      = "5035be37a7e9abbdc09f0d257f3e33416c1a0fb322ba860d42d74aa75c3468d4"
+  iso_checksum      = local.ubuntu_sha256.0
   iso_checksum_type = "sha256"
-  iso_url           = "http://releases.ubuntu.com/20.04/ubuntu-20.04.5-live-server-amd64.iso"
+  iso_url           = "https://releases.ubuntu.com/22.04/ubuntu-22.04.${local.ubuntu_url_path.0}-live-server-amd64.iso"
 
   sr_iso_name    = var.sr_iso_name
   sr_name        = var.sr_name
@@ -65,7 +84,7 @@ source "xenserver-iso" "ubuntu-2004" {
   vm_name        = "packer-ubuntu-2004-${local.timestamp}"
   vm_description = "Build started: ${local.timestamp}"
   vm_memory      = 4096
-  disk_size      = 20000
+  disk_size      = 30720
 
   floppy_files = [
     "examples/http/ubuntu-2004/meta-data",


### PR DESCRIPTION
When Ubuntu releases a new ISO, they remove the previous URL. Unfortunately this URL is hardcoded in the packer HCL template and so the example requires frequent changes as upstream releases new minor releases.

This change takes advantage of the packer 1.8 `http` [data source](https://developer.hashicorp.com/packer/docs/datasources/http#body) and allows the example to dynamically discover the checksum and URL to use. This will ensure that the example always works, and will prevent friction when new users try out this packer plugin.

## Testing
- [x] Ran the packer plugin and verified that it discovered the correct URL
```
ddelnano@ddelnano-desktop:~/go/src/github.com/xenserver/packer-plugin-xenserver$ packer1.8 build examples/ubuntu/ubuntu-2004.pkr.hcl
xenserver-iso.ubuntu-2004: output will be in this color.

==> xenserver-iso.ubuntu-2004: XAPI client session established
==> xenserver-iso.ubuntu-2004: Retrieving ISO
==> xenserver-iso.ubuntu-2004: Trying https://releases.ubuntu.com/22.04/ubuntu-22.04.2-live-server-amd64.iso
==> xenserver-iso.ubuntu-2004: Trying https://releases.ubuntu.com/22.04/ubuntu-22.04.2-live-server-amd64.iso?checksum=5e38b55d57d94ff029719342357325ed3bda38fa80054f9330dc789cd2d43931
Cancelling build after receiving interrupt
==> xenserver-iso.ubuntu-2004: https://releases.ubuntu.com/22.04/ubuntu-22.04.2-live-server-amd64.iso?checksum=5e38b55d57d94ff029719342357325ed3bda38fa80054f9330dc789cd2d43931 => /home/ddelnano/.cache/packer/c8e223803e24553af3f4bf186c28f2298d18a61a
Build 'xenserver-iso.ubuntu-2004' errored after 10 seconds 946 milliseconds: Build was cancelled.

==> Wait completed after 10 seconds 947 milliseconds
Cleanly cancelled builds after being interrupted.
```