### PR TITLE
Prevent ISO used in iso builder from being uploaded if it already exists

### DIFF
--- a/builder/xenserver/common/step_find_or_upload_vdi.go
+++ b/builder/xenserver/common/step_find_or_upload_vdi.go
@@ -1,0 +1,44 @@
+package common
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	"github.com/hashicorp/packer-plugin-sdk/packer"
+)
+
+type StepFindOrUploadVdi struct {
+	StepUploadVdi
+}
+
+func (self *StepFindOrUploadVdi) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	ui := state.Get("ui").(packer.Ui)
+	c := state.Get("client").(*Connection)
+	vdiName := self.VdiNameFunc()
+
+	ui.Say(fmt.Sprintf("Attemping to find VDI '%s'", vdiName))
+
+	vdis, err := c.client.VDI.GetByNameLabel(c.session, vdiName)
+	if err != nil {
+		ui.Error(fmt.Sprintf("Failed to find VDI '%s' by name label: %s", vdiName, err.Error()))
+		return multistep.ActionHalt
+	}
+
+	if len(vdis) > 1 {
+		ui.Error(fmt.Sprintf("Found more than one VDI with name '%s'. Name must be unique", vdiName))
+		return multistep.ActionHalt
+	} else if len(vdis) == 1 {
+
+		vdi := vdis[0]
+
+		vdiUuid, err := c.client.VDI.GetUUID(c.session, vdi)
+		if err != nil {
+			ui.Error(fmt.Sprintf("Unable to get UUID of VDI '%s': %s", vdiName, err.Error()))
+			return multistep.ActionHalt
+		}
+		state.Put(self.VdiUuidKey, vdiUuid)
+		return multistep.ActionContinue
+	}
+	return self.uploadVdi(ctx, state)
+}

--- a/builder/xenserver/common/step_upload_vdi.go
+++ b/builder/xenserver/common/step_upload_vdi.go
@@ -18,7 +18,7 @@ type StepUploadVdi struct {
 	VdiUuidKey    string
 }
 
-func (self *StepUploadVdi) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+func (self *StepUploadVdi) uploadVdi(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	config := state.Get("commonconfig").(CommonConfig)
 	ui := state.Get("ui").(packer.Ui)
 	c := state.Get("client").(*Connection)
@@ -33,10 +33,8 @@ func (self *StepUploadVdi) Run(ctx context.Context, state multistep.StateBag) mu
 	ui.Say(fmt.Sprintf("Step: Upload VDI '%s'", vdiName))
 
 	// Create VDI for the image
-	srs, err := c.client.SR.GetAll(c.session)
-	ui.Say(fmt.Sprintf("Step: Found SRs '%v'", srs))
-
 	sr, err := config.GetISOSR(c)
+	ui.Say(fmt.Sprintf("Step: Found SR for upload '%v'", sr))
 
 	if err != nil {
 		ui.Error(fmt.Sprintf("Unable to get SR: %v", err))
@@ -94,6 +92,10 @@ func (self *StepUploadVdi) Run(ctx context.Context, state multistep.StateBag) mu
 	}
 
 	return multistep.ActionContinue
+}
+
+func (self *StepUploadVdi) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	return self.uploadVdi(ctx, state)
 }
 
 func (self *StepUploadVdi) Cleanup(state multistep.StateBag) {

--- a/builder/xenserver/iso/builder.go
+++ b/builder/xenserver/iso/builder.go
@@ -187,7 +187,6 @@ func (self *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (p
 			Url:         self.config.ISOUrls,
 		},
 	}
-
 	steps := []multistep.Step{
 		&xscommon.StepPrepareOutputDir{
 			Force: self.config.PackerForce,
@@ -212,20 +211,22 @@ func (self *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (p
 			},
 			VdiUuidKey: "floppy_vdi_uuid",
 		},
-		&xscommon.StepUploadVdi{
-			VdiNameFunc: func() string {
-				if len(self.config.ISOUrls) > 0 {
-					return path.Base(self.config.ISOUrls[0])
-				}
-				return ""
+		&xscommon.StepFindOrUploadVdi{
+			xscommon.StepUploadVdi{
+				VdiNameFunc: func() string {
+					if len(self.config.ISOUrls) > 0 {
+						return path.Base(self.config.ISOUrls[0])
+					}
+					return ""
+				},
+				ImagePathFunc: func() string {
+					if isoPath, ok := state.GetOk("iso_path"); ok {
+						return isoPath.(string)
+					}
+					return ""
+				},
+				VdiUuidKey: "iso_vdi_uuid",
 			},
-			ImagePathFunc: func() string {
-				if isoPath, ok := state.GetOk("iso_path"); ok {
-					return isoPath.(string)
-				}
-				return ""
-			},
-			VdiUuidKey: "iso_vdi_uuid",
 		},
 		&xscommon.StepFindVdi{
 			VdiName:    self.config.ToolsIsoName,


### PR DESCRIPTION
This addresses #53 

## Testing
- [x] Ran back to back builds and verified that the second build did not upload the ISO
<details>
<summary>packer build output</summary>

```
# First build that uploads the iso

ddelnano@ddelnano-desktop:~/go/src/github.com/xenserver/packer-plugin-xenserver$ PACKER_LOG=1 packer1.8 build -debug  examples/ubuntu/ubuntu-2004.pkr.hcl
2023/02/26 22:54:21 [INFO] Packer version: 1.8.1 [go1.17.8 linux amd64]
2023/02/26 22:54:21 Old default config directory found: /home/ddelnano/.packer.d
2023/02/26 22:54:21 [TRACE] discovering plugins in /usr/local/bin
2023/02/26 22:54:21 Old default config directory found: /home/ddelnano/.packer.d
2023/02/26 22:54:21 [TRACE] discovering plugins in /home/ddelnano/.packer.d/plugins
2023/02/26 22:54:21 [DEBUG] Discovered plugin: xenserver = /home/ddelnano/.packer.d/plugins/github.com/ddelnano/xenserver/packer-plugin-xenserver_v0.5.1_x5.0_linux_amd64
2023/02/26 22:54:21 [DEBUG] Discovered plugin: upcloud = /home/ddelnano/.packer.d/plugins/github.com/upcloudltd/upcloud/packer-plugin-upcloud_v1.0.0_x5.0_linux_amd64
2023/02/26 22:54:21 [INFO] found external [iso xva] builders from xenserver plugin
2023/02/26 22:54:21 [INFO] found external [-packer-default-plugin-name-] builders from upcloud plugin
2023/02/26 22:54:21 [DEBUG] Discovered plugin: xenserver = /home/ddelnano/.packer.d/plugins/packer-plugin-xenserver
2023/02/26 22:54:21 [INFO] found external [iso xva] builders from xenserver plugin
2023/02/26 22:54:21 [TRACE] discovering plugins in .
2023/02/26 22:54:21 [DEBUG] Discovered plugin: xenserver = /home/ddelnano/go/src/github.com/xenserver/packer-plugin-xenserver/packer-builder-xenserver
2023/02/26 22:54:21 [INFO] using external builders: [xenserver]
2023/02/26 22:54:21 [INFO] PACKER_CONFIG env var not set; checking the default config file path
2023/02/26 22:54:21 [INFO] PACKER_CONFIG env var set; attempting to open config file: /home/ddelnano/.packerconfig
2023/02/26 22:54:21 [WARN] Config file doesn't exist: /home/ddelnano/.packerconfig
2023/02/26 22:54:21 Old default config directory found: /home/ddelnano/.packer.d
2023/02/26 22:54:21 [INFO] Setting cache directory: /home/ddelnano/.cache/packer
2023/02/26 22:54:21 Old default config directory found: /home/ddelnano/.packer.d
2023/02/26 22:54:21 [TRACE] validateValue: not active for remote_host, so skipping
2023/02/26 22:54:21 [TRACE] validateValue: not active for remote_password, so skipping
2023/02/26 22:54:21 [TRACE] validateValue: not active for remote_username, so skipping
2023/02/26 22:54:21 [TRACE] validateValue: not active for sr_iso_name, so skipping
2023/02/26 22:54:21 [TRACE] validateValue: not active for sr_name, so skipping
2023/02/26 22:54:21 [TRACE] Starting internal plugin packer-datasource-http
2023/02/26 22:54:21 Starting plugin: /usr/local/bin/packer1.8 []string{"/usr/local/bin/packer1.8", "plugin", "packer-datasource-http"}
2023/02/26 22:54:21 Waiting for RPC address for: /usr/local/bin/packer1.8
2023/02/26 22:54:21 packer1.8 plugin: [INFO] Packer version: 1.8.1 [go1.17.8 linux amd64]
2023/02/26 22:54:21 packer1.8 plugin: Old default config directory found: /home/ddelnano/.packer.d
2023/02/26 22:54:21 packer1.8 plugin: [INFO] PACKER_CONFIG env var not set; checking the default config file path
2023/02/26 22:54:21 packer1.8 plugin: [INFO] PACKER_CONFIG env var set; attempting to open config file: /home/ddelnano/.packerconfig
2023/02/26 22:54:21 packer1.8 plugin: [WARN] Config file doesn't exist: /home/ddelnano/.packerconfig
2023/02/26 22:54:21 packer1.8 plugin: Old default config directory found: /home/ddelnano/.packer.d
2023/02/26 22:54:21 packer1.8 plugin: [INFO] Setting cache directory: /home/ddelnano/.cache/packer
2023/02/26 22:54:21 packer1.8 plugin: args: []string{"packer-datasource-http"}
2023/02/26 22:54:21 packer1.8 plugin: Old default config directory found: /home/ddelnano/.packer.d
2023/02/26 22:54:21 packer1.8 plugin: Plugin address: unix /tmp/packer-plugin3504349629
2023/02/26 22:54:21 Received unix RPC address for /usr/local/bin/packer1.8: addr is /tmp/packer-plugin3504349629
2023/02/26 22:54:21 packer1.8 plugin: Waiting for connection...
2023/02/26 22:54:21 packer1.8 plugin: Serving a plugin connection...
2023/02/26 22:54:22 [TRACE] Starting external plugin /home/ddelnano/.packer.d/plugins/packer-plugin-xenserver start builder iso
2023/02/26 22:54:22 Starting plugin: /home/ddelnano/.packer.d/plugins/packer-plugin-xenserver []string{"/home/ddelnano/.packer.d/plugins/packer-plugin-xenserver", "start", "builder", "iso"}
2023/02/26 22:54:22 Waiting for RPC address for: /home/ddelnano/.packer.d/plugins/packer-plugin-xenserver
2023/02/26 22:54:22 packer-plugin-xenserver plugin: 2023/02/26 22:54:22 Plugin address: unix /tmp/packer-plugin532483945
2023/02/26 22:54:22 packer-plugin-xenserver plugin: 2023/02/26 22:54:22 Waiting for connection...
2023/02/26 22:54:22 Received unix RPC address for /home/ddelnano/.packer.d/plugins/packer-plugin-xenserver: addr is /tmp/packer-plugin532483945
2023/02/26 22:54:22 packer-plugin-xenserver plugin: 2023/02/26 22:54:22 Serving a plugin connection...
2023/02/26 22:54:22 packer-plugin-xenserver plugin: 2023/02/26 22:54:22 [TRACE] starting builder iso
Debug mode enabled. Builds will not be parallelized.
xenserver-iso.ubuntu-2004: output will be in this color.

2023/02/26 22:54:22 Build debug mode: true
2023/02/26 22:54:22 Force build: false
2023/02/26 22:54:22 On error:
2023/02/26 22:54:22 Debug enabled, so waiting for build to finish: xenserver-iso.ubuntu-2004
2023/02/26 22:54:22 Starting build run: xenserver-iso.ubuntu-2004
2023/02/26 22:54:22 Running builder:
2023/02/26 22:54:22 [INFO] (telemetry) Starting builder xenserver-iso.ubuntu-2004
==> xenserver-iso.ubuntu-2004: XAPI client session established
==> xenserver-iso.ubuntu-2004: Retrieving ISO
==> xenserver-iso.ubuntu-2004: Trying https://releases.ubuntu.com/20.04/ubuntu-20.04.5-live-server-amd64.iso
2023/02/26 22:54:22 packer-plugin-xenserver plugin: 2023/02/26 22:54:22 Acquiring lock for: https://releases.ubuntu.com/20.04/ubuntu-20.04.5-live-server-amd64.iso?checksum=5035be37a7e9abbdc09f0d257f3e33416c1a0fb322ba860d42d74aa75c3468d4 (/home/ddelnano/.cache/packer/69568d54c016f7b458b59d62c25f14a6988488b0.lock)
==> xenserver-iso.ubuntu-2004: Trying https://releases.ubuntu.com/20.04/ubuntu-20.04.5-live-server-amd64.iso?checksum=5035be37a7e9abbdc09f0d257f3e33416c1a0fb322ba860d42d74aa75c3468d4
==> xenserver-iso.ubuntu-2004: https://releases.ubuntu.com/20.04/ubuntu-20.04.5-live-server-amd64.iso?checksum=5035be37a7e9abbdc09f0d257f3e33416c1a0fb322ba860d42d74aa75c3468d4 => /home/ddelnano/.cache/packer/69568d54c016f7b458b59d62c25f14a6988488b0
2023/02/26 22:54:30 packer-plugin-xenserver plugin: 2023/02/26 22:54:30 Leaving retrieve loop for ISO
2023/02/26 22:54:30 packer-plugin-xenserver plugin: 2023/02/26 22:54:30 Floppy label is set to cidata
==> xenserver-iso.ubuntu-2004: Creating floppy disk...
2023/02/26 22:54:30 packer-plugin-xenserver plugin: 2023/02/26 22:54:30 Floppy path: /tmp/packer300450228
2023/02/26 22:54:30 packer-plugin-xenserver plugin: 2023/02/26 22:54:30 Initializing block device backed by temporary file
2023/02/26 22:54:30 packer-plugin-xenserver plugin: 2023/02/26 22:54:30 Formatting the block device with a FAT filesystem...
2023/02/26 22:54:30 packer-plugin-xenserver plugin: 2023/02/26 22:54:30 Initializing FAT filesystem on block device
2023/02/26 22:54:30 packer-plugin-xenserver plugin: 2023/02/26 22:54:30 Reading the <sensitive> directory from the filesystem
    xenserver-iso.ubuntu-2004: Copying files flatly from floppy_files
    xenserver-iso.ubuntu-2004: Copying file: examples/http/ubuntu-2004/meta-data
    xenserver-iso.ubuntu-2004: Copying file: examples/http/ubuntu-2004/user-data
    xenserver-iso.ubuntu-2004: Done copying files from floppy_files
    xenserver-iso.ubuntu-2004: Collecting paths from floppy_dirs
    xenserver-iso.ubuntu-2004: Resulting paths from floppy_dirs : []
    xenserver-iso.ubuntu-2004: Done copying paths from floppy_dirs
    xenserver-iso.ubuntu-2004: Copying files from floppy_content
    xenserver-iso.ubuntu-2004: Done copying files from floppy_content
==> xenserver-iso.ubuntu-2004: Step: Upload VDI 'Packer-floppy-disk'
==> xenserver-iso.ubuntu-2004: Step: Found SR for upload 'OpaqueRef:5aea74a2-edf3-4542-ad46-7d7ac4bf9a96'
==> xenserver-iso.ubuntu-2004: PUT 'https://<sensitive>/import_raw_vdi?session_id=OpaqueRef%3Ac3694dcd-4587-47e4-a11a-503300e39477&task_id=OpaqueRef%3A6d44deca-8516-4447-bdaf-c2a3d1a48590&vdi=OpaqueRef%3A1823850f-ce03-4a3f-a357-d51d75548d42'
2023/02/26 22:54:36 packer-plugin-xenserver plugin: 2023/02/26 22:54:36 Upload complete
==> xenserver-iso.ubuntu-2004: Attemping to find VDI 'ubuntu-20.04.5-live-server-amd64.iso'
==> xenserver-iso.ubuntu-2004: Step: Upload VDI 'ubuntu-20.04.5-live-server-amd64.iso'
==> xenserver-iso.ubuntu-2004: Step: Found SR for upload 'OpaqueRef:5aea74a2-edf3-4542-ad46-7d7ac4bf9a96'
==> xenserver-iso.ubuntu-2004: PUT 'https://<sensitive>/import_raw_vdi?session_id=OpaqueRef%3Ac3694dcd-4587-47e4-a11a-503300e39477&task_id=OpaqueRef%3Ad08e96eb-ccff-4524-a860-695f35cf5ab1&vdi=OpaqueRef%3Aada1dbb7-6780-4c0d-8816-65d506271703'
2023/02/26 22:54:42 packer-plugin-xenserver plugin: 2023/02/26 22:54:42 Upload 15% complete
2023/02/26 22:54:47 packer-plugin-xenserver plugin: 2023/02/26 22:54:47 Upload 40% complete
2023/02/26 22:54:52 packer-plugin-xenserver plugin: 2023/02/26 22:54:52 Upload 69% complete
2023/02/26 22:54:57 packer-plugin-xenserver plugin: 2023/02/26 22:54:57 Upload 97% complete
2023/02/26 22:55:00 packer-plugin-xenserver plugin: 2023/02/26 22:55:00 Upload complete
==> xenserver-iso.ubuntu-2004: Step: Create Instance
==> xenserver-iso.ubuntu-2004: Using the following SR for the VM: OpaqueRef:5aea74a2-edf3-4542-ad46-7d7ac4bf9a96
2023/02/26 22:55:02 packer-plugin-xenserver plugin: 2023/02/26 22:55:02 No network name given, attempting to use management interface
2023/02/26 22:55:02 packer-plugin-xenserver plugin: 2023/02/26 22:55:02 Creating VIF on network 'OpaqueRef:a6cf15fd-0d17-45ab-953a-4849980ee0ce' on VM 'OpaqueRef:3fe2eddc-c47b-4489-9bec-588d58f43094'
2023/02/26 22:55:02 packer-plugin-xenserver plugin: 2023/02/26 22:55:02 Created the following VIF: OpaqueRef:6b7d24e3-4c83-47d3-afaa-2d83151e76ab
==> xenserver-iso.ubuntu-2004: Created instance 'a493321a-ecc8-df34-23b3-8423bcbde130'
2023/02/26 22:55:02 packer-plugin-xenserver plugin: 2023/02/26 22:55:02 Running attach vdi for key floppy_vdi_uuid
2023/02/26 22:55:02 packer-plugin-xenserver plugin: 2023/02/26 22:55:02 Attached VDI '097a7d1b-1339-4c9c-91a5-f86e5fc14eeb'
2023/02/26 22:55:02 packer-plugin-xenserver plugin: 2023/02/26 22:55:02 Running attach vdi for key iso_vdi_uuid
2023/02/26 22:55:02 packer-plugin-xenserver plugin: 2023/02/26 22:55:02 Attached VDI '0eba5e01-c355-49d5-bcfd-753de869e212'
2023/02/26 22:55:02 packer-plugin-xenserver plugin: 2023/02/26 22:55:02 Running attach vdi for key isoname_vdi_uuid
2023/02/26 22:55:02 packer-plugin-xenserver plugin: 2023/02/26 22:55:02 Skipping attach of 'isoname_vdi_uuid'
2023/02/26 22:55:02 packer-plugin-xenserver plugin: 2023/02/26 22:55:02 Running attach vdi for key tools_vdi_uuid
2023/02/26 22:55:02 packer-plugin-xenserver plugin: 2023/02/26 22:55:02 Attached VDI 'c39a39b8-0cfe-4199-a565-c07ae26f6d57'
==> xenserver-iso.ubuntu-2004: Step: Start VM Paused
==> xenserver-iso.ubuntu-2004: Step: Set SSH address to VM host IP
==> xenserver-iso.ubuntu-2004: Set host SSH address to '<sensitive>'.
==> xenserver-iso.ubuntu-2004: Unpausing VM a493321a-ecc8-df34-23b3-8423bcbde130
==> xenserver-iso.ubuntu-2004: Waiting 5s for boot...
==> xenserver-iso.ubuntu-2004: Step: Wait for VM's IP to become known to us.
    xenserver-iso.ubuntu-2004: Got IP '192.168.88.37' from XenServer tools
==> xenserver-iso.ubuntu-2004: Got IP address '192.168.88.37'
2023/02/26 23:11:09 packer-plugin-xenserver plugin: 2023/02/26 23:11:09 Looking for an available port between 5900 and 6000
2023/02/26 23:11:09 packer-plugin-xenserver plugin: 2023/02/26 23:11:09 Trying port: 5900
==> xenserver-iso.ubuntu-2004: Creating a local port forward over SSH on local port 5900
==> xenserver-iso.ubuntu-2004: Port forward setup. 5900 ---> 192.168.88.37:22 on <sensitive>
==> xenserver-iso.ubuntu-2004: Using SSH communicator to connect: 192.168.88.37
==> xenserver-iso.ubuntu-2004: Waiting for SSH to become available...
2023/02/26 23:11:09 packer-plugin-xenserver plugin: 2023/02/26 
2023/02/26 23:16:25 packer-plugin-xenserver plugin: 2023/02/26 23:16:25 [DEBUG] handshake complete!
2023/02/26 23:16:25 packer-plugin-xenserver plugin: 2023/02/26 23:16:25 [ERROR] could not connect to local agent socket: /home/ddelnano/.ssh/ssh_auth_sock
==> xenserver-iso.ubuntu-2004: Connected to SSH!
2023/02/26 23:16:25 packer-plugin-xenserver plugin: 2023/02/26 23:16:25 Running the provision hook
==> xenserver-iso.ubuntu-2004: Step: Shutting down VM
    xenserver-iso.ubuntu-2004: Attempting to cleanly shutdown the VM...
    xenserver-iso.ubuntu-2004: Successfully shut down VM
    xenserver-iso.ubuntu-2004: Successfully set VM as a template
2023/02/26 23:16:58 packer-plugin-xenserver plugin: 2023/02/26 23:16:58 Could not find VDI record in VBD 'OpaqueRef:d9867287-9b9d-4fa9-9afb-6088ed0e7c0b'
2023/02/26 23:16:58 packer-plugin-xenserver plugin: 2023/02/26 23:16:58 Detached VDI '0eba5e01-c355-49d5-bcfd-753de869e212'
2023/02/26 23:16:58 packer-plugin-xenserver plugin: 2023/02/26 23:16:58 Skipping detach of 'isoname_vdi_uuid'
2023/02/26 23:16:58 packer-plugin-xenserver plugin: 2023/02/26 23:16:58 Detached VDI 'c39a39b8-0cfe-4199-a565-c07ae26f6d57'
2023/02/26 23:16:58 packer-plugin-xenserver plugin: 2023/02/26 23:16:58 Detached VDI '097a7d1b-1339-4c9c-91a5-f86e5fc14eeb'
==> xenserver-iso.ubuntu-2004: Step: export artifact
==> xenserver-iso.ubuntu-2004: Getting XVA https://<sensitive>/export?uuid=a493321a-ecc8-df34-23b3-8423bcbde130&session_id=OpaqueRef:c3694dcd-4587-47e4-a11a-503300e39477
==> xenserver-iso.ubuntu-2004: Download completed: packer-ubuntu-2004-iso
2023/02/26 23:18:44 [INFO] (telemetry) ending xenserver-iso.ubuntu-2004
2023/02/26 23:18:44 Waiting on builds to complete...
==> Wait completed after 24 minutes 22 seconds
==> Builds finished. The artifacts of successful builds are:
2023/02/26 23:18:44 machine readable: xenserver-iso.ubuntu-2004,artifact-count []string{"1"}
Build 'xenserver-iso.ubuntu-2004' finished after 24 minutes 22 seconds.

2023/02/26 23:18:44 machine readable: xenserver-iso.ubuntu-2004,artifact []string{"0", "builder-id", "packer.xenserver"}
2023/02/26 23:18:44 machine readable: xenserver-iso.ubuntu-2004,artifact []string{"0", "id", "VM"}
2023/02/26 23:18:44 machine readable: xenserver-iso.ubuntu-2004,artifact []string{"0", "string", "VM files in directory: packer-ubuntu-2004-iso"}
2023/02/26 23:18:44 machine readable: xenserver-iso.ubuntu-2004,artifact []string{"0", "files-count", "1"}
2023/02/26 23:18:44 machine readable: xenserver-iso.ubuntu-2004,artifact []string{"0", "file", "0", "packer-ubuntu-2004-iso/packer-ubuntu-2004-20230227065422.xva"}
2023/02/26 23:18:44 machine readable: xenserver-iso.ubuntu-2004,artifact []string{"0", "end"}
2023/02/26 23:18:44 [INFO] (telemetry) Finalizing.
==> Wait completed after 24 minutes 22 seconds
2023/02/26 23:18:44 packer-plugin-xenserver plugin: 2023/02/26 23:18:44 Deleting floppy disk: /tmp/packer300450228

==> Builds finished. The artifacts of successful builds are:
--> xenserver-iso.ubuntu-2004: VM files in directory: packer-ubuntu-2004-iso
2023/02/26 23:18:45 waiting for all plugin processes to complete...
2023/02/26 23:18:45 /home/ddelnano/.packer.d/plugins/packer-plugin-xenserver: plugin process exited
2023/02/26 23:18:45 /usr/local/bin/packer1.8: plugin process exited

# Second build that reuses the first build's ISO
ddelnano@ddelnano-desktop:~/go/src/github.com/xenserver/packer-plugin-xenserver$ PACKER_LOG=1 packer1.8 build -debug  examples/ubuntu/ubuntu-2004.pkr.hcl
2023/02/26 23:19:43 [INFO] Packer version: 1.8.1 [go1.17.8 linux amd64]
2023/02/26 23:19:43 Old default config directory found: /home/ddelnano/.packer.d
2023/02/26 23:19:43 [TRACE] discovering plugins in /usr/local/bin
2023/02/26 23:19:43 Old default config directory found: /home/ddelnano/.packer.d
2023/02/26 23:19:43 [TRACE] discovering plugins in /home/ddelnano/.packer.d/plugins
2023/02/26 23:19:43 [DEBUG] Discovered plugin: xenserver = /home/ddelnano/.packer.d/plugins/github.com/ddelnano/xenserver/packer-plugin-xenserver_v0.5.1_x5.0_linux_amd64
2023/02/26 23:19:43 [DEBUG] Discovered plugin: upcloud = /home/ddelnano/.packer.d/plugins/github.com/upcloudltd/upcloud/packer-plugin-upcloud_v1.0.0_x5.0_linux_amd64
2023/02/26 23:19:43 [INFO] found external [iso xva] builders from xenserver plugin
2023/02/26 23:19:44 [INFO] found external [-packer-default-plugin-name-] builders from upcloud plugin
2023/02/26 23:19:44 [DEBUG] Discovered plugin: xenserver = /home/ddelnano/.packer.d/plugins/packer-plugin-xenserver
2023/02/26 23:19:44 [INFO] found external [iso xva] builders from xenserver plugin
2023/02/26 23:19:44 [TRACE] discovering plugins in .
2023/02/26 23:19:44 [DEBUG] Discovered plugin: xenserver = /home/ddelnano/go/src/github.com/xenserver/packer-plugin-xenserver/packer-builder-xenserver
2023/02/26 23:19:44 [INFO] using external builders: [xenserver]
2023/02/26 23:19:44 [INFO] PACKER_CONFIG env var not set; checking the default config file path
2023/02/26 23:19:44 [INFO] PACKER_CONFIG env var set; attempting to open config file: /home/ddelnano/.packerconfig
2023/02/26 23:19:44 [WARN] Config file doesn't exist: /home/ddelnano/.packerconfig
2023/02/26 23:19:44 Old default config directory found: /home/ddelnano/.packer.d
2023/02/26 23:19:44 [INFO] Setting cache directory: /home/ddelnano/.cache/packer
2023/02/26 23:19:44 Old default config directory found: /home/ddelnano/.packer.d
2023/02/26 23:19:44 [TRACE] validateValue: not active for remote_host, so skipping
2023/02/26 23:19:44 [TRACE] validateValue: not active for remote_password, so skipping
2023/02/26 23:19:44 [TRACE] validateValue: not active for remote_username, so skipping
2023/02/26 23:19:44 [TRACE] validateValue: not active for sr_iso_name, so skipping
2023/02/26 23:19:44 [TRACE] validateValue: not active for sr_name, so skipping
2023/02/26 23:19:44 [TRACE] Starting internal plugin packer-datasource-http
2023/02/26 23:19:44 Starting plugin: /usr/local/bin/packer1.8 []string{"/usr/local/bin/packer1.8", "plugin", "packer-datasource-http"}
2023/02/26 23:19:44 Waiting for RPC address for: /usr/local/bin/packer1.8
2023/02/26 23:19:44 packer1.8 plugin: [INFO] Packer version: 1.8.1 [go1.17.8 linux amd64]
2023/02/26 23:19:44 packer1.8 plugin: Old default config directory found: /home/ddelnano/.packer.d
2023/02/26 23:19:44 packer1.8 plugin: [INFO] PACKER_CONFIG env var not set; checking the default config file path
2023/02/26 23:19:44 packer1.8 plugin: [INFO] PACKER_CONFIG env var set; attempting to open config file: /home/ddelnano/.packerconfig
2023/02/26 23:19:44 packer1.8 plugin: [WARN] Config file doesn't exist: /home/ddelnano/.packerconfig
2023/02/26 23:19:44 packer1.8 plugin: Old default config directory found: /home/ddelnano/.packer.d
2023/02/26 23:19:44 packer1.8 plugin: [INFO] Setting cache directory: /home/ddelnano/.cache/packer
2023/02/26 23:19:44 packer1.8 plugin: args: []string{"packer-datasource-http"}
2023/02/26 23:19:44 packer1.8 plugin: Old default config directory found: /home/ddelnano/.packer.d
2023/02/26 23:19:44 Received unix RPC address for /usr/local/bin/packer1.8: addr is /tmp/packer-plugin4041928589
2023/02/26 23:19:44 packer1.8 plugin: Plugin address: unix /tmp/packer-plugin4041928589
2023/02/26 23:19:44 packer1.8 plugin: Waiting for connection...
2023/02/26 23:19:44 packer1.8 plugin: Serving a plugin connection...
2023/02/26 23:19:44 [TRACE] Starting external plugin /home/ddelnano/.packer.d/plugins/packer-plugin-xenserver start builder iso
2023/02/26 23:19:44 Starting plugin: /home/ddelnano/.packer.d/plugins/packer-plugin-xenserver []string{"/home/ddelnano/.packer.d/plugins/packer-plugin-xenserver", "start", "builder", "iso"}
2023/02/26 23:19:44 Waiting for RPC address for: /home/ddelnano/.packer.d/plugins/packer-plugin-xenserver
2023/02/26 23:19:44 packer-plugin-xenserver plugin: 2023/02/26 23:19:44 Plugin address: unix /tmp/packer-plugin951804283
2023/02/26 23:19:44 packer-plugin-xenserver plugin: 2023/02/26 23:19:44 Waiting for connection...
2023/02/26 23:19:44 Received unix RPC address for /home/ddelnano/.packer.d/plugins/packer-plugin-xenserver: addr is /tmp/packer-plugin951804283
2023/02/26 23:19:44 packer-plugin-xenserver plugin: 2023/02/26 23:19:44 Serving a plugin connection...
2023/02/26 23:19:44 packer-plugin-xenserver plugin: 2023/02/26 23:19:44 [TRACE] starting builder iso
2023/02/26 23:19:44 Build debug mode: true
2023/02/26 23:19:44 Force build: false
Debug mode enabled. Builds will not be parallelized.
xenserver-iso.ubuntu-2004: output will be in this color.
2023/02/26 23:19:44 On error:
2023/02/26 23:19:44 Debug enabled, so waiting for build to finish: xenserver-iso.ubuntu-2004

2023/02/26 23:19:44 Starting build run: xenserver-iso.ubuntu-2004
2023/02/26 23:19:44 Running builder:
2023/02/26 23:19:44 [INFO] (telemetry) Starting builder xenserver-iso.ubuntu-2004
==> xenserver-iso.ubuntu-2004: XAPI client session established
==> xenserver-iso.ubuntu-2004: Retrieving ISO
2023/02/26 23:19:44 packer-plugin-xenserver plugin: 2023/02/26 23:19:44 Acquiring lock for: https://releases.ubuntu.com/20.04/ubuntu-20.04.5-live-server-amd64.iso?checksum=5035be37a7e9abbdc09f0d257f3e33416c1a0fb322ba860d42d74aa75c3468d4 (/home/ddelnano/.cache/packer/69568d54c016f7b458b59d62c25f14a6988488b0.lock)
==> xenserver-iso.ubuntu-2004: Trying https://releases.ubuntu.com/20.04/ubuntu-20.04.5-live-server-amd64.iso
==> xenserver-iso.ubuntu-2004: Trying https://releases.ubuntu.com/20.04/ubuntu-20.04.5-live-server-amd64.iso?checksum=5035be37a7e9abbdc09f0d257f3e33416c1a0fb322ba860d42d74aa75c3468d4
2023/02/26 23:19:53 packer-plugin-xenserver plugin: 2023/02/26 23:19:53 Leaving retrieve loop for ISO
2023/02/26 23:19:53 packer-plugin-xenserver plugin: 2023/02/26 23:19:53 Floppy label is set to cidata
==> xenserver-iso.ubuntu-2004: https://releases.ubuntu.com/20.04/ubuntu-20.04.5-live-server-amd64.iso?checksum=5035be37a7e9abbdc09f0d257f3e33416c1a0fb322ba860d42d74aa75c3468d4 => /home/ddelnano/.cache/packer/69568d54c016f7b458b59d62c25f14a6988488b0
2023/02/26 23:19:53 packer-plugin-xenserver plugin: 2023/02/26 23:19:53 Floppy path: /tmp/packer106220702
2023/02/26 23:19:53 packer-plugin-xenserver plugin: 2023/02/26 23:19:53 Initializing block device backed by temporary file
2023/02/26 23:19:53 packer-plugin-xenserver plugin: 2023/02/26 23:19:53 Formatting the block device with a FAT filesystem...
2023/02/26 23:19:53 packer-plugin-xenserver plugin: 2023/02/26 23:19:53 Initializing FAT filesystem on block device
2023/02/26 23:19:53 packer-plugin-xenserver plugin: 2023/02/26 23:19:53 Reading the <sensitive> directory from the filesystem
==> xenserver-iso.ubuntu-2004: Creating floppy disk...
    xenserver-iso.ubuntu-2004: Copying files flatly from floppy_files
    xenserver-iso.ubuntu-2004: Copying file: examples/http/ubuntu-2004/meta-data
    xenserver-iso.ubuntu-2004: Copying file: examples/http/ubuntu-2004/user-data
    xenserver-iso.ubuntu-2004: Done copying files from floppy_files
    xenserver-iso.ubuntu-2004: Collecting paths from floppy_dirs
    xenserver-iso.ubuntu-2004: Resulting paths from floppy_dirs : []
    xenserver-iso.ubuntu-2004: Done copying paths from floppy_dirs
    xenserver-iso.ubuntu-2004: Copying files from floppy_content
    xenserver-iso.ubuntu-2004: Done copying files from floppy_content
==> xenserver-iso.ubuntu-2004: Step: Upload VDI 'Packer-floppy-disk'
==> xenserver-iso.ubuntu-2004: Step: Found SR for upload 'OpaqueRef:5aea74a2-edf3-4542-ad46-7d7ac4bf9a96'
==> xenserver-iso.ubuntu-2004: PUT 'https://<sensitive>/import_raw_vdi?session_id=OpaqueRef%3Ab2578db6-dc47-406e-b3c2-1a9649351d90&task_id=OpaqueRef%3A286efeff-73b6-449b-9626-4131dbbbcd56&vdi=OpaqueRef%3A6106de1f-4d3c-4ce9-8bac-3b389ce2716a'
2023/02/26 23:19:59 packer-plugin-xenserver plugin: 2023/02/26 23:19:59 Upload complete
==> xenserver-iso.ubuntu-2004: Attemping to find VDI 'ubuntu-20.04.5-live-server-amd64.iso'
==> xenserver-iso.ubuntu-2004: Step: Create Instance
==> xenserver-iso.ubuntu-2004: Using the following SR for the VM: OpaqueRef:5aea74a2-edf3-4542-ad46-7d7ac4bf9a96
2023/02/26 23:20:03 packer-plugin-xenserver plugin: 2023/02/26 23:20:03 No network name given, attempting to use management interface
2023/02/26 23:20:03 packer-plugin-xenserver plugin: 2023/02/26 23:20:03 Creating VIF on network 'OpaqueRef:a6cf15fd-0d17-45ab-953a-4849980ee0ce' on VM 'OpaqueRef:4fc86554-d039-4536-b2d5-b089b87a37cd'
2023/02/26 23:20:03 packer-plugin-xenserver plugin: 2023/02/26 23:20:03 Created the following VIF: OpaqueRef:e4bba0cb-c6f6-4db6-b9a5-1d537e550314
==> xenserver-iso.ubuntu-2004: Created instance '60aa68af-894e-4810-f5ce-6368e65584af'
2023/02/26 23:20:03 packer-plugin-xenserver plugin: 2023/02/26 23:20:03 Running attach vdi for key floppy_vdi_uuid
2023/02/26 23:20:03 packer-plugin-xenserver plugin: 2023/02/26 23:20:03 Attached VDI '19b27d7d-e628-4db8-865a-6a8968cae87e'
2023/02/26 23:20:03 packer-plugin-xenserver plugin: 2023/02/26 23:20:03 Running attach vdi for key iso_vdi_uuid
2023/02/26 23:20:03 packer-plugin-xenserver plugin: 2023/02/26 23:20:03 Attached VDI '0eba5e01-c355-49d5-bcfd-753de869e212'
2023/02/26 23:20:03 packer-plugin-xenserver plugin: 2023/02/26 23:20:03 Running attach vdi for key isoname_vdi_uuid
2023/02/26 23:20:03 packer-plugin-xenserver plugin: 2023/02/26 23:20:03 Skipping attach of 'isoname_vdi_uuid'
2023/02/26 23:20:03 packer-plugin-xenserver plugin: 2023/02/26 23:20:03 Running attach vdi for key tools_vdi_uuid
2023/02/26 23:20:03 packer-plugin-xenserver plugin: 2023/02/26 23:20:03 Attached VDI 'c39a39b8-0cfe-4199-a565-c07ae26f6d57'
==> xenserver-iso.ubuntu-2004: Step: Start VM Paused
==> xenserver-iso.ubuntu-2004: Step: Set SSH address to VM host IP

```

</details>