### PR TITLE
Allow ISO Storage repository to fallback to default SR if unspecified

### DIFF
--- a/builder/xenserver/common/common_config.go
+++ b/builder/xenserver/common/common_config.go
@@ -20,7 +20,7 @@ type CommonConfig struct {
 	VMName             string   `mapstructure:"vm_name"`
 	VMDescription      string   `mapstructure:"vm_description"`
 	SrName             string   `mapstructure:"sr_name"`
-	SrISOName          string   `mapstructure:"sr_iso_name"`
+	SrISOName          string   `mapstructure:"sr_iso_name" required:"false"`
 	FloppyFiles        []string `mapstructure:"floppy_files"`
 	NetworkNames       []string `mapstructure:"network_names"`
 	ExportNetworkNames []string `mapstructure:"export_network_names"`

--- a/builder/xenserver/common/config.hcl2spec.go
+++ b/builder/xenserver/common/config.hcl2spec.go
@@ -24,7 +24,7 @@ type FlatConfig struct {
 	VMName                    *string           `mapstructure:"vm_name" cty:"vm_name" hcl:"vm_name"`
 	VMDescription             *string           `mapstructure:"vm_description" cty:"vm_description" hcl:"vm_description"`
 	SrName                    *string           `mapstructure:"sr_name" cty:"sr_name" hcl:"sr_name"`
-	SrISOName                 *string           `mapstructure:"sr_iso_name" cty:"sr_iso_name" hcl:"sr_iso_name"`
+	SrISOName                 *string           `mapstructure:"sr_iso_name" required:"false" cty:"sr_iso_name" hcl:"sr_iso_name"`
 	FloppyFiles               []string          `mapstructure:"floppy_files" cty:"floppy_files" hcl:"floppy_files"`
 	NetworkNames              []string          `mapstructure:"network_names" cty:"network_names" hcl:"network_names"`
 	ExportNetworkNames        []string          `mapstructure:"export_network_names" cty:"export_network_names" hcl:"export_network_names"`


### PR DESCRIPTION
#63 missed an update to the config structures.

Testing
- [x] Verify that default iso fallback works. Currently this is failing because the config structures are still requiring that sr_iso_name is defined as seen below