### PR TITLE
Allow support for adding tags to VMs

### DIFF
--- a/builder/xenserver/common/client.go
+++ b/builder/xenserver/common/client.go
@@ -624,6 +624,17 @@ func ConnectNetwork(c *Connection, networkRef xenapi.NetworkRef, vmRef xenapi.VM
 	return &vif, nil
 }
 
+func AddVMTags(c *Connection, vmRef xenapi.VMRef, tags []string) error {
+	for _, tag := range tags {
+		log.Printf("Adding tag %s to VM %s\n", tag, vmRef)
+		err := c.GetClient().VM.AddTags(c.session, vmRef, tag)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 //      Setters
 
 func (self *VM) SetIsATemplate(is_a_template bool) (err error) {

--- a/builder/xenserver/common/common_config.go
+++ b/builder/xenserver/common/common_config.go
@@ -24,6 +24,7 @@ type CommonConfig struct {
 	FloppyFiles        []string `mapstructure:"floppy_files"`
 	NetworkNames       []string `mapstructure:"network_names"`
 	ExportNetworkNames []string `mapstructure:"export_network_names"`
+	VMTags             []string `mapstructure:"vm_tags"`
 
 	HostPortMin uint `mapstructure:"host_port_min"`
 	HostPortMax uint `mapstructure:"host_port_max"`

--- a/builder/xenserver/common/config.go
+++ b/builder/xenserver/common/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	DiskSize       uint              `mapstructure:"disk_size"`
 	CloneTemplate  string            `mapstructure:"clone_template"`
 	VMOtherConfig  map[string]string `mapstructure:"vm_other_config"`
+	VMTags         []string          `mapstructure:"vm_tags"`
 
 	ISOChecksum string   `mapstructure:"iso_checksum"`
 	ISOUrls     []string `mapstructure:"iso_urls"`

--- a/builder/xenserver/common/config.hcl2spec.go
+++ b/builder/xenserver/common/config.hcl2spec.go
@@ -28,6 +28,7 @@ type FlatConfig struct {
 	FloppyFiles               []string          `mapstructure:"floppy_files" cty:"floppy_files" hcl:"floppy_files"`
 	NetworkNames              []string          `mapstructure:"network_names" cty:"network_names" hcl:"network_names"`
 	ExportNetworkNames        []string          `mapstructure:"export_network_names" cty:"export_network_names" hcl:"export_network_names"`
+	VMTags                    []string          `mapstructure:"vm_tags" cty:"vm_tags" hcl:"vm_tags"`
 	HostPortMin               *uint             `mapstructure:"host_port_min" cty:"host_port_min" hcl:"host_port_min"`
 	HostPortMax               *uint             `mapstructure:"host_port_max" cty:"host_port_max" hcl:"host_port_max"`
 	BootCommand               []string          `mapstructure:"boot_command" cty:"boot_command" hcl:"boot_command"`
@@ -140,6 +141,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"floppy_files":                 &hcldec.AttrSpec{Name: "floppy_files", Type: cty.List(cty.String), Required: false},
 		"network_names":                &hcldec.AttrSpec{Name: "network_names", Type: cty.List(cty.String), Required: false},
 		"export_network_names":         &hcldec.AttrSpec{Name: "export_network_names", Type: cty.List(cty.String), Required: false},
+		"vm_tags":                      &hcldec.AttrSpec{Name: "vm_tags", Type: cty.List(cty.String), Required: false},
 		"host_port_min":                &hcldec.AttrSpec{Name: "host_port_min", Type: cty.Number, Required: false},
 		"host_port_max":                &hcldec.AttrSpec{Name: "host_port_max", Type: cty.Number, Required: false},
 		"boot_command":                 &hcldec.AttrSpec{Name: "boot_command", Type: cty.List(cty.String), Required: false},

--- a/builder/xenserver/common/step_create_instance.go
+++ b/builder/xenserver/common/step_create_instance.go
@@ -216,6 +216,12 @@ func (self *StepCreateInstance) Run(ctx context.Context, state multistep.StateBa
 		}
 	}
 
+	err = AddVMTags(c, instance, config.VMTags)
+	if err != nil {
+		ui.Error(fmt.Sprintf("Failed to add tags: %s", err.Error()))
+		return multistep.ActionHalt
+	}
+
 	instanceId, err := c.GetClient().VM.GetUUID(c.GetSessionRef(), instance)
 	if err != nil {
 		ui.Error(fmt.Sprintf("Unable to get VM UUID: %s", err.Error()))

--- a/builder/xenserver/xva/step_import_instance.go
+++ b/builder/xenserver/xva/step_import_instance.go
@@ -86,6 +86,12 @@ func (self *stepImportInstance) Run(ctx context.Context, state multistep.StateBa
 		return multistep.ActionHalt
 	}
 
+	err = xscommon.AddVMTags(c, instance, config.VMTags)
+	if err != nil {
+		ui.Error(fmt.Sprintf("Failed to add tags: %s", err.Error()))
+		return multistep.ActionHalt
+	}
+
 	ui.Say(fmt.Sprintf("Imported instance '%s'", instanceId))
 
 	return multistep.ActionContinue

--- a/docs/builders/iso/xenserver-iso.html.markdown
+++ b/docs/builders/iso/xenserver-iso.html.markdown
@@ -207,6 +207,8 @@ each category, the available options are alphabetized and described.
 * `vm_memory` (integer) - The size, in megabytes, of the amount of memory to
   allocate for the VM. By default, this is 1024 (1 GB).
 
+* `vm_tags` (array of strings) - A list of tags to add to the VM
+
 ## Differences with other Packer builders
 
 Currently the XenServer builder has some quirks when compared with other Packer builders.


### PR DESCRIPTION
This is a continuation of #45 and must be rebased after #66 is merged.

## Testing
- [x] Verify that vms can be created with tags
- [x] Verify that vms can be created without tags (default setting)