### PR TITLE
Let user choose if they want tools or not.

### DIFF
--- a/builder/xenserver/common/common_config.go
+++ b/builder/xenserver/common/common_config.go
@@ -76,10 +76,6 @@ func (c *CommonConfig) Prepare(ctx *interpolate.Context, pc *common.PackerConfig
 		c.RawBootWait = "5s"
 	}
 
-	if c.ToolsIsoName == "" {
-		c.ToolsIsoName = ""
-	}
-
 	if c.HTTPPortMin == 0 {
 		c.HTTPPortMin = 8000
 	}

--- a/builder/xenserver/common/common_config.go
+++ b/builder/xenserver/common/common_config.go
@@ -77,7 +77,7 @@ func (c *CommonConfig) Prepare(ctx *interpolate.Context, pc *common.PackerConfig
 	}
 
 	if c.ToolsIsoName == "" {
-		c.ToolsIsoName = "xs-tools.iso"
+		c.ToolsIsoName = ""
 	}
 
 	if c.HTTPPortMin == 0 {

--- a/docs/builders/iso/xenserver-iso.html.markdown
+++ b/docs/builders/iso/xenserver-iso.html.markdown
@@ -133,6 +133,9 @@ each category, the available options are alphabetized and described.
   must point to the same file (same checksum). By default this is empty
   and `iso_url` is used. Only one of `iso_url` or `iso_urls` can be specified.
 
+* `tools_iso_name` (string) - Choose the tools iso you want to use. 
+   Usually "guest-tools.iso", or "xs-tools.iso". Not setting this variable won't plug any tools.
+
 * `keep_vm` (string) - Determine when to keep the VM and when to clean it up. This
   can be "always", "never" or "on_success". By default this is "never", and Packer
   always deletes the VM regardless of whether the process succeeded and an artifact

--- a/packer.json
+++ b/packer.json
@@ -1,6 +1,6 @@
 {
     "builders": [{
         "type": "xenserver-iso",
-        "tools_iso_name": "guest-tools.iso"
+        "tools_iso_name": ""
     }]
 }

--- a/packer.json
+++ b/packer.json
@@ -1,6 +1,0 @@
-{
-    "builders": [{
-        "type": "xenserver-iso",
-        "tools_iso_name": ""
-    }]
-}


### PR DESCRIPTION
I had some problem with the packer provider and Debian installation. Debian detect the tools ISO as a CD (it's logical, it's a CD) and try to parse it as a Debian disk. Obviously, that didn't work.

Since I found a way to install the tools with preseed (yeah it's ugly, but working):
```
d-i preseed/late_command string in-target wget https://github.com/xenserver/xe-guest-utilities/releases/download/v7.20.2/xe-guest-utilities_7.20.2-1_amd64.deb; in-target export RUNLEVEL=1; in-target dpkg -i xe-guest-utilities_7.20.2-1_amd64.deb`
```
and in your Ubuntu example, guest-tools are in the repo:
```
  packages:
    - xe-guest-utilities
```
I don't think plugging the ISO tools is needed anymore.

Other user who need to have tools can always plug it by setting `tools_iso_name = "guest-tools.iso"` in their pkr.hcl.

Tested both use-case after recompiling (with tools_iso_name set and not set) and it's working on my side, but I'm open to other test :)

I'm not a go developer, so maybe it's not the best way to handle this