### PR TITLE
Allow users to specify if xs tools should be managed by packer or not

### DIFF
--- a/builder/xenserver/common/common_config.go
+++ b/builder/xenserver/common/common_config.go
@@ -76,10 +76,6 @@ func (c *CommonConfig) Prepare(ctx *interpolate.Context, pc *common.PackerConfig
 		c.RawBootWait = "5s"
 	}
 
-	if c.ToolsIsoName == "" {
-		c.ToolsIsoName = ""
-	}
-
 	if c.HTTPPortMin == 0 {
 		c.HTTPPortMin = 8000
 	}

--- a/builder/xenserver/common/common_config.go
+++ b/builder/xenserver/common/common_config.go
@@ -77,7 +77,7 @@ func (c *CommonConfig) Prepare(ctx *interpolate.Context, pc *common.PackerConfig
 	}
 
 	if c.ToolsIsoName == "" {
-		c.ToolsIsoName = "xs-tools.iso"
+		c.ToolsIsoName = ""
 	}
 
 	if c.HTTPPortMin == 0 {

--- a/builder/xenserver/iso/builder_test.go
+++ b/builder/xenserver/iso/builder_test.go
@@ -4,21 +4,20 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer-plugin-sdk/common"
+	"github.com/hashicorp/packer-plugin-sdk/packer"
 )
-
 
 func testConfig() map[string]interface{} {
 	return map[string]interface{}{
-		"remote_host":       "localhost",
-		"remote_username":   "admin",
-		"remote_password":   "admin",
-		"vm_name":           "foo",
-		"iso_checksum":      "md5:A221725EE181A44C67E25BD6A2516742",
-		"iso_url":           "http://www.google.com/",
-		"shutdown_command":  "yes",
-		"ssh_username":      "foo",
+		"remote_host":      "localhost",
+		"remote_username":  "admin",
+		"remote_password":  "admin",
+		"vm_name":          "foo",
+		"iso_checksum":     "md5:A221725EE181A44C67E25BD6A2516742",
+		"iso_url":          "http://www.google.com/",
+		"shutdown_command": "yes",
+		"ssh_username":     "foo",
 
 		common.BuildNameConfigKey: "foo",
 	}
@@ -43,7 +42,7 @@ func TestBuilderPrepare_Defaults(t *testing.T) {
 		t.Fatalf("should not have error: %s", err)
 	}
 
-	if b.config.ToolsIsoName != "xs-tools.iso" {
+	if b.config.ToolsIsoName != "" {
 		t.Errorf("bad tools ISO name: %s", b.config.ToolsIsoName)
 	}
 
@@ -201,9 +200,7 @@ func TestBuilderPrepare_ISOChecksum(t *testing.T) {
 		t.Fatal("should have error")
 	}
 
-
 }
-
 
 func TestBuilderPrepare_ISOUrl(t *testing.T) {
 	var b Builder

--- a/builder/xenserver/xva/builder_test.go
+++ b/builder/xenserver/xva/builder_test.go
@@ -3,8 +3,8 @@ package xva
 import (
 	"testing"
 
-	"github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer-plugin-sdk/common"
+	"github.com/hashicorp/packer-plugin-sdk/packer"
 )
 
 func testConfig() map[string]interface{} {
@@ -40,7 +40,7 @@ func TestBuilderPrepare_Defaults(t *testing.T) {
 		t.Fatalf("should not have error: %s", err)
 	}
 
-	if b.config.ToolsIsoName != "xs-tools.iso" {
+	if b.config.ToolsIsoName != "" {
 		t.Errorf("bad tools ISO name: %s", b.config.ToolsIsoName)
 	}
 

--- a/docs/builders/iso/xenserver-iso.html.markdown
+++ b/docs/builders/iso/xenserver-iso.html.markdown
@@ -133,6 +133,9 @@ each category, the available options are alphabetized and described.
   must point to the same file (same checksum). By default this is empty
   and `iso_url` is used. Only one of `iso_url` or `iso_urls` can be specified.
 
+* `tools_iso_name` (string) - Choose the tools iso you want to use. 
+   Usually "guest-tools.iso", or "xs-tools.iso". Not setting this variable won't plug any tools.
+
 * `keep_vm` (string) - Determine when to keep the VM and when to clean it up. This
   can be "always", "never" or "on_success". By default this is "never", and Packer
   always deletes the VM regardless of whether the process succeeded and an artifact

--- a/packer.json
+++ b/packer.json
@@ -1,6 +1,6 @@
 {
     "builders": [{
         "type": "xenserver-iso",
-        "tools_iso_name": "guest-tools.iso"
+        "tools_iso_name": ""
     }]
 }

--- a/packer.json
+++ b/packer.json
@@ -1,6 +1,0 @@
-{
-    "builders": [{
-        "type": "xenserver-iso",
-        "tools_iso_name": ""
-    }]
-}


### PR DESCRIPTION
This is a continuation of #82. The additional change included in this one is getting the tests to pass (they needed to be updated to test against the new default value)