### PR TITLE
Add configuration for github release generation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,14 @@
+changelog:
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - breaking-change
+    - title: New Features 🎉
+      labels:
+        - enhancement
+    - title: Bug fixes
+      labels:
+        - bug
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,8 +4,7 @@ env:
   - CGO_ENABLED=0
 before:
   hooks:
-    # TODO(ddelnano): for now there aren't tests to run
-    # - go test ./...
+    - go test ./...
     # As part of the release doc files are included as a separate deliverable for
     # consumption by Packer.io. To include a separate docs.zip uncomment the following command.
     #- make ci-release-docs
@@ -68,7 +67,7 @@ signs:
       - "--detach-sign"
       - "${artifact}"
 release:
-  draft: true
+  draft: false
 
 changelog:
   skip: true


### PR DESCRIPTION
This change will streamline the release process by allowing labels to dictate how the release notes are generated. I started using this on another one of my projects and have been happy with it so far (https://github.com/ddelnano/terraform-provider-mikrotik/)