### PR TITLE
Add remote_ssh_port packer option

### DIFF
--- a/builder/xenserver/common/common_config.go
+++ b/builder/xenserver/common/common_config.go
@@ -13,9 +13,10 @@ import (
 )
 
 type CommonConfig struct {
-	Username string `mapstructure:"remote_username"`
-	Password string `mapstructure:"remote_password"`
-	HostIp   string `mapstructure:"remote_host"`
+	Username    string `mapstructure:"remote_username"`
+	Password    string `mapstructure:"remote_password"`
+	HostIp      string `mapstructure:"remote_host"`
+	HostSshPort uint   `mapstructure:"remote_ssh_port"`
 
 	VMName             string   `mapstructure:"vm_name"`
 	VMDescription      string   `mapstructure:"vm_description"`
@@ -63,6 +64,10 @@ func (c *CommonConfig) Prepare(ctx *interpolate.Context, pc *common.PackerConfig
 	var errs []error
 
 	// Set default values
+
+	if c.HostSshPort == 0 {
+		c.HostSshPort = 22
+	}
 
 	if c.HostPortMin == 0 {
 		c.HostPortMin = 5900

--- a/builder/xenserver/common/config.hcl2spec.go
+++ b/builder/xenserver/common/config.hcl2spec.go
@@ -21,6 +21,7 @@ type FlatConfig struct {
 	Username                  *string           `mapstructure:"remote_username" cty:"remote_username" hcl:"remote_username"`
 	Password                  *string           `mapstructure:"remote_password" cty:"remote_password" hcl:"remote_password"`
 	HostIp                    *string           `mapstructure:"remote_host" cty:"remote_host" hcl:"remote_host"`
+	HostSshPort               *uint             `mapstructure:"remote_ssh_port" cty:"remote_ssh_port" hcl:"remote_ssh_port"`
 	VMName                    *string           `mapstructure:"vm_name" cty:"vm_name" hcl:"vm_name"`
 	VMDescription             *string           `mapstructure:"vm_description" cty:"vm_description" hcl:"vm_description"`
 	SrName                    *string           `mapstructure:"sr_name" cty:"sr_name" hcl:"sr_name"`
@@ -136,6 +137,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"remote_username":              &hcldec.AttrSpec{Name: "remote_username", Type: cty.String, Required: false},
 		"remote_password":              &hcldec.AttrSpec{Name: "remote_password", Type: cty.String, Required: false},
 		"remote_host":                  &hcldec.AttrSpec{Name: "remote_host", Type: cty.String, Required: false},
+		"remote_ssh_port":              &hcldec.AttrSpec{Name: "remote_ssh_port", Type: cty.Number, Required: false},
 		"vm_name":                      &hcldec.AttrSpec{Name: "vm_name", Type: cty.String, Required: false},
 		"vm_description":               &hcldec.AttrSpec{Name: "vm_description", Type: cty.String, Required: false},
 		"sr_name":                      &hcldec.AttrSpec{Name: "sr_name", Type: cty.String, Required: false},

--- a/builder/xenserver/common/ssh.go
+++ b/builder/xenserver/common/ssh.go
@@ -114,10 +114,10 @@ func ExecuteGuestSSHCmd(state multistep.StateBag, cmd string) (stdout string, er
 	return doExecuteSSHCmd(cmd, localAddress, sshConfig)
 }
 
-func forward(local_conn net.Conn, config *gossh.ClientConfig, server, remote_dest string, remote_port uint) error {
+func forward(local_conn net.Conn, config *gossh.ClientConfig, server string, server_ssh_port int, remote_dest string, remote_port uint) error {
 	defer local_conn.Close()
 
-	ssh_client_conn, err := gossh.Dial("tcp", server+":22", config)
+	ssh_client_conn, err := gossh.Dial("tcp", fmt.Sprintf("%s:%d", server, server_ssh_port), config)
 	if err != nil {
 		log.Printf("local ssh.Dial error: %s", err)
 		return err
@@ -157,7 +157,7 @@ func forward(local_conn net.Conn, config *gossh.ClientConfig, server, remote_des
 	return nil
 }
 
-func ssh_port_forward(local_listener net.Listener, remote_port int, remote_dest, host, username, password string) error {
+func ssh_port_forward(local_listener net.Listener, remote_port int, remote_dest, host string, host_ssh_port int, username, password string) error {
 
 	config := &gossh.ClientConfig{
 		User: username,
@@ -176,7 +176,7 @@ func ssh_port_forward(local_listener net.Listener, remote_port int, remote_dest,
 		}
 
 		// Forward to a remote port
-		go forward(local_connection, config, host, remote_dest, uint(remote_port))
+		go forward(local_connection, config, host, host_ssh_port, remote_dest, uint(remote_port))
 	}
 
 	return nil

--- a/builder/xenserver/common/ssh.go
+++ b/builder/xenserver/common/ssh.go
@@ -17,7 +17,7 @@ import (
 
 func SSHAddress(state multistep.StateBag) (string, error) {
 	sshIP := state.Get("ssh_address").(string)
-	sshHostPort := 22
+	sshHostPort := state.Get("ssh_port").(uint)
 	return fmt.Sprintf("%s:%d", sshIP, sshHostPort), nil
 }
 

--- a/builder/xenserver/common/step_forward_port_over_ssh.go
+++ b/builder/xenserver/common/step_forward_port_over_ssh.go
@@ -35,10 +35,11 @@ func (self *StepForwardPortOverSSH) Run(ctx context.Context, state multistep.Sta
 	ui.Say(fmt.Sprintf("Creating a local port forward over SSH on local port %d", sshHostPort))
 
 	hostAddress, _ := state.Get("ssh_address").(string)
+	hostSshPort, _ := state.Get("ssh_port").(int)
 	remotePort, _ := self.RemotePort(state)
 	remoteDest, _ := self.RemoteDest(state)
 
-	go ssh_port_forward(l, remotePort, remoteDest, hostAddress, config.Username, config.Password)
+	go ssh_port_forward(l, remotePort, remoteDest, hostAddress, hostSshPort, config.Username, config.Password)
 	ui.Say(fmt.Sprintf("Port forward setup. %d ---> %s:%d on %s", sshHostPort, remoteDest, remotePort, hostAddress))
 
 	// Provide the local port to future steps.

--- a/builder/xenserver/common/step_set_vm_host_ssh_address.go
+++ b/builder/xenserver/common/step_set_vm_host_ssh_address.go
@@ -13,6 +13,7 @@ type StepSetVmHostSshAddress struct{}
 func (self *StepSetVmHostSshAddress) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 
 	c := state.Get("client").(*Connection)
+	config := state.Get("config").(Config)
 	ui := state.Get("ui").(packer.Ui)
 
 	ui.Say("Step: Set SSH address to VM host IP")
@@ -36,6 +37,9 @@ func (self *StepSetVmHostSshAddress) Run(ctx context.Context, state multistep.St
 
 	state.Put("ssh_address", address)
 	ui.Say(fmt.Sprintf("Set host SSH address to '%s'.", address))
+
+	state.Put("ssh_port", config.HostSshPort)
+	ui.Say(fmt.Sprintf("Set host SSH port to %d.", config.HostSshPort))
 
 	return multistep.ActionContinue
 }

--- a/builder/xenserver/iso/builder_test.go
+++ b/builder/xenserver/iso/builder_test.go
@@ -61,6 +61,10 @@ func TestBuilderPrepare_Defaults(t *testing.T) {
 	if b.config.KeepVM != "never" {
 		t.Errorf("bad keep instance: %s", b.config.KeepVM)
 	}
+
+	if b.config.HostSshPort != 22 {
+		t.Errorf("bad ssh port: %d", b.config.HostSshPort)
+	}
 }
 
 func TestBuilderPrepare_DiskSize(t *testing.T) {

--- a/builder/xenserver/xva/builder_test.go
+++ b/builder/xenserver/xva/builder_test.go
@@ -55,6 +55,10 @@ func TestBuilderPrepare_Defaults(t *testing.T) {
 	if b.config.KeepVM != "never" {
 		t.Errorf("bad keep instance: %s", b.config.KeepVM)
 	}
+
+	if b.config.HostSshPort != 22 {
+		t.Errorf("bad ssh port: %d", b.config.HostSshPort)
+	}
 }
 
 func TestBuilderPrepare_Format(t *testing.T) {

--- a/docs/builders/iso/xenserver-iso.html.markdown
+++ b/docs/builders/iso/xenserver-iso.html.markdown
@@ -58,6 +58,8 @@ each category, the available options are alphabetized and described.
 * `remote_host` (string) - The host of the Xenserver / XCP-ng pool primary. Typically, these will be specified through
   environment variables as seen in the [examples](../../../examples).
 
+* `remote_ssh_port` (integer) - The port that SSH will be listening on in the Xenserver / XCP-ng pool primary. By default this is 22.
+
 * `remote_username` (string) - The XenServer username used to access the remote machine.
 
 * `remote_password` (string) - The XenServer password for access to the remote machine.


### PR DESCRIPTION
This PR adds a Packer configuration option `remote_ssh_port` for Xen and XCP-ng primary servers that expose the SSH service on a port different than 22.