### PR TITLE
Allow user to set VDI name

### DIFF
--- a/builder/xenserver/common/config.go
+++ b/builder/xenserver/common/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	VCPUsMax       uint              `mapstructure:"vcpus_max"`
 	VCPUsAtStartup uint              `mapstructure:"vcpus_atstartup"`
 	VMMemory       uint              `mapstructure:"vm_memory"`
+	DiskName       string            `mapstructure:"disk_name"`
 	DiskSize       uint              `mapstructure:"disk_size"`
 	CloneTemplate  string            `mapstructure:"clone_template"`
 	VMOtherConfig  map[string]string `mapstructure:"vm_other_config"`

--- a/builder/xenserver/common/config.hcl2spec.go
+++ b/builder/xenserver/common/config.hcl2spec.go
@@ -98,6 +98,7 @@ type FlatConfig struct {
 	VCPUsMax                  *uint             `mapstructure:"vcpus_max" cty:"vcpus_max" hcl:"vcpus_max"`
 	VCPUsAtStartup            *uint             `mapstructure:"vcpus_atstartup" cty:"vcpus_atstartup" hcl:"vcpus_atstartup"`
 	VMMemory                  *uint             `mapstructure:"vm_memory" cty:"vm_memory" hcl:"vm_memory"`
+	DiskName                  *string           `mapstructure:"disk_name" cty:"disk_name" hcl:"disk_name"`
 	DiskSize                  *uint             `mapstructure:"disk_size" cty:"disk_size" hcl:"disk_size"`
 	CloneTemplate             *string           `mapstructure:"clone_template" cty:"clone_template" hcl:"clone_template"`
 	VMOtherConfig             map[string]string `mapstructure:"vm_other_config" cty:"vm_other_config" hcl:"vm_other_config"`
@@ -212,6 +213,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"vcpus_max":                    &hcldec.AttrSpec{Name: "vcpus_max", Type: cty.Number, Required: false},
 		"vcpus_atstartup":              &hcldec.AttrSpec{Name: "vcpus_atstartup", Type: cty.Number, Required: false},
 		"vm_memory":                    &hcldec.AttrSpec{Name: "vm_memory", Type: cty.Number, Required: false},
+		"disk_name":                    &hcldec.AttrSpec{Name: "disk_name", Type: cty.String, Required: false},
 		"disk_size":                    &hcldec.AttrSpec{Name: "disk_size", Type: cty.Number, Required: false},
 		"clone_template":               &hcldec.AttrSpec{Name: "clone_template", Type: cty.String, Required: false},
 		"vm_other_config":              &hcldec.AttrSpec{Name: "vm_other_config", Type: cty.Map(cty.String), Required: false},

--- a/builder/xenserver/common/step_create_instance.go
+++ b/builder/xenserver/common/step_create_instance.go
@@ -122,7 +122,7 @@ func (self *StepCreateInstance) Run(ctx context.Context, state multistep.StateBa
 		ui.Say(fmt.Sprintf("Using the following SR for the VM: %s", sr))
 
 		vdi, err := c.GetClient().VDI.Create(c.GetSessionRef(), xenapi.VDIRecord{
-			NameLabel:   "Packer-disk",
+			NameLabel:   config.DiskName,
 			VirtualSize: int(config.DiskSize * 1024 * 1024),
 			Type:        "user",
 			Sharable:    false,

--- a/builder/xenserver/iso/builder.go
+++ b/builder/xenserver/iso/builder.go
@@ -53,6 +53,10 @@ func (self *Builder) Prepare(raws ...interface{}) (params []string, warns []stri
 		self.config.RawInstallTimeout = "200m"
 	}
 
+	if self.config.DiskName == "" {
+		self.config.DiskName = "Packer-disk"
+	}
+
 	if self.config.DiskSize == 0 {
 		self.config.DiskSize = 40000
 	}


### PR DESCRIPTION
Before this PR, the VDI name was hardcoded
With this PR, the user can set the name of the VDI.

Tested on my side:
```
uuid ( RO)                : 6121a165-1d0c-426e-9c9c-b16e5a928fbc
          name-label ( RW): MyCustomeName-disk
    name-description ( RW): 
             sr-uuid ( RO): d0125395-80c1-663e-dd80-8315c990bc79
        virtual-size ( RO): 21474836480
            sharable ( RO): false
           read-only ( RO): false
```
