### PR TITLE
Change version in main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	// Version is the main version number that is being run at the moment.
-	Version = "v0.6.0"
+	Version = "v0.7.0"
 
 	// VersionPrerelease is A pre-release marker for the Version. If this is ""
 	// (empty string) then it means that it is a final release. Otherwise, this


### PR DESCRIPTION
Since the last packer update (1.11.0, release on the 2024-05-31), Hashicorp introduce a breaking change.

A colleague installed today the last packer version and had this message:
```
packer init build-the-VM.pkr.hcl 
Failed getting the "github.com/ddelnano/xenserver" plugin:
2 errors occurred:
    * Continuing to next available version: binary reported version ("v0.6.0") is different from the expected "0.7.0", skipping
    * could not install any compatible version of plugin "github.com/ddelnano/xenserver"
```
He had to downgrade his packer to stay on version 1.10.3.

I checked in the plugin code by curiosity, and saw it was simply a line in the main.go that needed a change :D

So, this is my PR :)

I suppose I can be automated, but I have no idea how to do that.

Thank you for your time and your work @ddelnano 
