### PR TITLE
Fix plugin installation on 1.11.0 and later by fixing release version detection

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,25 +11,11 @@ import (
 	"github.com/hashicorp/packer-plugin-sdk/version"
 )
 
-var (
-	// Version is the main version number that is being run at the moment.
-	Version = "v0.6.0"
-
-	// VersionPrerelease is A pre-release marker for the Version. If this is ""
-	// (empty string) then it means that it is a final release. Otherwise, this
-	// is a pre-release such as "dev" (in development), "beta", "rc1", etc.
-	VersionPrerelease = ""
-
-	// PluginVersion is used by the plugin set to allow Packer to recognize
-	// what version this plugin is.
-	PluginVersion = version.InitializePluginVersion(Version, VersionPrerelease)
-)
-
 func main() {
 	pps := plugin.NewSet()
 	pps.RegisterBuilder("iso", new(iso.Builder))
 	pps.RegisterBuilder("xva", new(xva.Builder))
-	pps.SetVersion(PluginVersion)
+	pps.SetVersion(version.PluginVersion)
 	err := pps.Run()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())

--- a/main.go
+++ b/main.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/xenserver/packer-builder-xenserver/builder/xenserver/iso"
 	"github.com/xenserver/packer-builder-xenserver/builder/xenserver/xva"
+	"github.com/xenserver/packer-builder-xenserver/version"
 
 	"github.com/hashicorp/packer-plugin-sdk/plugin"
-	"github.com/hashicorp/packer-plugin-sdk/version"
 )
 
 func main() {

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,19 @@
+package version
+
+import (
+	"github.com/hashicorp/packer-plugin-sdk/version"
+)
+
+var (
+	// Version is the main version number that is being run at the moment.
+	Version = "v0.6.0"
+
+	// VersionPrerelease is A pre-release marker for the Version. If this is ""
+	// (empty string) then it means that it is a final release. Otherwise, this
+	// is a pre-release such as "dev" (in development), "beta", "rc1", etc.
+	VersionPrerelease = "dev"
+
+	// PluginVersion is used by the plugin set to allow Packer to recognize
+	// what version this plugin is.
+	PluginVersion = version.InitializePluginVersion(Version, VersionPrerelease)
+)


### PR DESCRIPTION
Summary: Fix plugin installation on 1.11.0 and later by fixing release version detection

This addresses #136 but will ensure that future releases don't need to be bumped. Setting the package level `version.Version` variable already existed in the [goreleaser configuration](https://github.com/ddelnano/packer-plugin-xenserver/blob/a776a46e1e600e0e854dfb8ac73aca876f8a8468/.goreleaser.yml#L32), but the variable was defined in the wrong package (`main.Version` instead of `version.Version`). 