### PR TITLE
When specifying a file for checksum, do not touch string case

### DIFF
--- a/builder/xenserver/common/step_export.go
+++ b/builder/xenserver/common/step_export.go
@@ -224,12 +224,14 @@ func (StepExport) Run(ctx context.Context, state multistep.StateBag) multistep.S
 			}
 
 			var disk_export_url string
+			var disk_export_url_masked string
 
 			// @todo: check for 6.5 SP1
 			if xs_version <= "6.5.0" && config.Format == "vdi_vhd" {
 				// Export the VHD using a Transfer VM
 
 				disk_export_url, err = Expose(c, disk, "vhd")
+				disk_export_url_masked = disk_export_url
 
 				if err != nil {
 					ui.Error(fmt.Sprintf("Failed to expose disk %s: %s", disk_uuid, err.Error()))
@@ -249,11 +251,17 @@ func (StepExport) Run(ctx context.Context, state multistep.StateBag) multistep.S
 					disk_uuid,
 					extrauri)
 
+				disk_export_url_masked = fmt.Sprintf("https://%s:%s@%s/export_raw_vdi?vdi=%s%s",
+					c.Username,
+					"********",
+					c.Host,
+					disk_uuid,
+					extrauri)
 			}
 
 			disk_export_filename := fmt.Sprintf("%s/%s%s", config.OutputDir, disk_uuid, suffix)
 
-			ui.Say("Getting VDI " + disk_export_url)
+			ui.Say("Getting VDI " + disk_export_url_masked)
 			err = downloadFile(disk_export_url, disk_export_filename, ui)
 			if err != nil {
 				ui.Error(fmt.Sprintf("Could not download VDI: %s", err.Error()))

--- a/builder/xenserver/iso/builder.go
+++ b/builder/xenserver/iso/builder.go
@@ -119,7 +119,10 @@ func (self *Builder) Prepare(raws ...interface{}) (params []string, warns []stri
 
 	if self.config.ISOName == "" {
 		// If ISO name is not specified, assume a URL and checksum has been provided.
-		self.config.ISOChecksum = strings.ToLower(self.config.ISOChecksum)
+		// If checksum is provided and starts with file:, do not change to lower case
+		if !strings.HasPrefix(strings.ToLower(self.config.ISOChecksum), "file:") {
+			self.config.ISOChecksum = strings.ToLower(self.config.ISOChecksum)
+		}
 
 		if len(self.config.ISOUrls) == 0 {
 			if self.config.ISOUrl == "" {


### PR DESCRIPTION
When specifying a `file:` for the `iso_checksum`, changing the case to lower can be a problem.  This doesn't touch the string if it's a file.