### PR TITLE
Improve boot command parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ builder-*
 dist/*
 vendor/*
 packer-plugin-xenserver
+packer-builder-xenserver

--- a/builder/xenserver/common/step_type_boot_command.go
+++ b/builder/xenserver/common/step_type_boot_command.go
@@ -11,16 +11,15 @@ import (
 	"net"
 	"strings"
 	"time"
-	"unicode"
-	"unicode/utf8"
 
+	"github.com/hashicorp/packer-plugin-sdk/bootcommand"
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	"github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
 	"github.com/mitchellh/go-vnc"
 )
 
-const KeyLeftShift uint = 0xFFE1
+const KeyLeftShift uint32 = 0xFFE1
 
 type bootCommandTemplateData struct {
 	Name     string
@@ -149,9 +148,13 @@ func (step *StepTypeBootCommand) Run(ctx context.Context, state multistep.StateB
 		uint(httpPort),
 	}
 
+	d := bootcommand.NewVNCDriver(vncClient, time.Second/10)
+
 	ui.Say("Typing boot commands over VNC...")
 	for _, command := range config.BootCommand {
-
+		if len(command) == 0 {
+			continue
+		}
 		command, err := interpolate.Render(command, &step.Ctx)
 		if err != nil {
 			err := fmt.Errorf("Error preparing boot command: %s", err)
@@ -160,112 +163,24 @@ func (step *StepTypeBootCommand) Run(ctx context.Context, state multistep.StateB
 			return multistep.ActionHalt
 		}
 
-		// Check for interrupts
-		if _, ok := state.GetOk(multistep.StateCancelled); ok {
+		seq, err := bootcommand.GenerateExpressionSequence(command)
+		if err != nil {
+			err := fmt.Errorf("Error generating boot command: %s", err)
+			state.Put("error", err)
+			ui.Error(err.Error())
 			return multistep.ActionHalt
 		}
 
-		vncSendString(vncClient, command)
+		if err := seq.Do(ctx, d); err != nil {
+			err := fmt.Errorf("Error running boot command: %s", err)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+
 	}
 
 	return multistep.ActionContinue
 }
 
 func (step *StepTypeBootCommand) Cleanup(multistep.StateBag) {}
-
-// Taken from qemu's builder plugin - not an exported function.
-func vncSendString(c *vnc.ClientConn, original string) {
-	// Scancodes reference: https://github.com/qemu/qemu/blob/master/ui/vnc_keysym.h
-	special := make(map[string]uint32)
-	special["<bs>"] = 0xFF08
-	special["<del>"] = 0xFFFF
-	special["<enter>"] = 0xFF0D
-	special["<esc>"] = 0xFF1B
-	special["<f1>"] = 0xFFBE
-	special["<f2>"] = 0xFFBF
-	special["<f3>"] = 0xFFC0
-	special["<f4>"] = 0xFFC1
-	special["<f5>"] = 0xFFC2
-	special["<f6>"] = 0xFFC3
-	special["<f7>"] = 0xFFC4
-	special["<f8>"] = 0xFFC5
-	special["<f9>"] = 0xFFC6
-	special["<f10>"] = 0xFFC7
-	special["<f11>"] = 0xFFC8
-	special["<f12>"] = 0xFFC9
-	special["<return>"] = 0xFF0D
-	special["<tab>"] = 0xFF09
-	special["<up>"] = 0xFF52
-	special["<down>"] = 0xFF54
-	special["<left>"] = 0xFF51
-	special["<right>"] = 0xFF53
-	special["<spacebar>"] = 0x020
-	special["<insert>"] = 0xFF63
-	special["<home>"] = 0xFF50
-	special["<end>"] = 0xFF57
-	special["<pageUp>"] = 0xFF55
-	special["<pageDown>"] = 0xFF56
-
-	shiftedChars := "~!@#$%^&*()_+{}|:\"<>?"
-
-	// TODO(mitchellh): Ripe for optimizations of some point, perhaps.
-	for len(original) > 0 {
-		var keyCode uint32
-		keyShift := false
-
-		if strings.HasPrefix(original, "<wait>") {
-			log.Printf("Special code '<wait>' found, sleeping one second")
-			time.Sleep(1 * time.Second)
-			original = original[len("<wait>"):]
-			continue
-		}
-
-		if strings.HasPrefix(original, "<wait5>") {
-			log.Printf("Special code '<wait5>' found, sleeping 5 seconds")
-			time.Sleep(5 * time.Second)
-			original = original[len("<wait5>"):]
-			continue
-		}
-
-		if strings.HasPrefix(original, "<wait10>") {
-			log.Printf("Special code '<wait10>' found, sleeping 10 seconds")
-			time.Sleep(10 * time.Second)
-			original = original[len("<wait10>"):]
-			continue
-		}
-
-		for specialCode, specialValue := range special {
-			if strings.HasPrefix(original, specialCode) {
-				log.Printf("Special code '%s' found, replacing with: %d", specialCode, specialValue)
-				keyCode = specialValue
-				original = original[len(specialCode):]
-				break
-			}
-		}
-
-		if keyCode == 0 {
-			r, size := utf8.DecodeRuneInString(original)
-			original = original[size:]
-			keyCode = uint32(r)
-			keyShift = unicode.IsUpper(r) || strings.ContainsRune(shiftedChars, r)
-
-			log.Printf("Sending char '%c', code %d, shift %v", r, keyCode, keyShift)
-		}
-
-		if keyShift {
-			c.KeyEvent(uint32(KeyLeftShift), true)
-		}
-
-		c.KeyEvent(keyCode, true)
-		time.Sleep(time.Second / 10)
-		c.KeyEvent(keyCode, false)
-		time.Sleep(time.Second / 10)
-
-		if keyShift {
-			c.KeyEvent(uint32(KeyLeftShift), false)
-		}
-
-		// no matter what, wait a small period
-		time.Sleep(50 * time.Millisecond)
-	}
-}

--- a/docs/builders/iso/xenserver-iso.html.markdown
+++ b/docs/builders/iso/xenserver-iso.html.markdown
@@ -299,8 +299,29 @@ will be replaced by the proper key:
 
 * `<pageUp>` `<pageDown>` - Simulates pressing the page up and page down keys.
 
+* `<leftAlt> <rightAlt>` - Simulates pressing the alt key.
+
+* `<leftCtrl> <rightCtrl>` - Simulates pressing the ctrl key.
+
+* `<leftShift> <rightShift>` - Simulates pressing the shift key.
+
+* `<leftSuper> <rightSuper>` - Simulates pressing the ⌘ or Windows key.
+
 * `<wait>` `<wait5>` `<wait10>` - Adds a 1, 5 or 10 second pause before sending any additional keys. This
   is useful if you have to generally wait for the UI to update before typing more.
+
+* `<waitXX>` - Add an arbitrary pause before sending any additional keys.
+  The format of `XX` is a sequence of positive decimal numbers, each with
+  optional fraction and a unit suffix, such as `300ms`, `1.5h` or `2h45m`.
+  Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. For
+  example `<wait10m>` or `<wait1m20s>`.
+
+* `<XXXOn> <XXXOff>` - Any printable keyboard character, and of these
+  "special" expressions, with the exception of the `<wait>` types, can
+  also be toggled on or off. For example, to simulate ctrl+c, use
+  `<leftCtrlOn>c<leftCtrlOff>`. Be sure to release them, otherwise they
+  will be held down until the machine reboots. To hold the `c` key down,
+  you would use `<cOn>`. Likewise, `<cOff>` to release.
 
 In addition to the special keys, each command to type is treated as a
 configuration template.

--- a/go.mod
+++ b/go.mod
@@ -81,6 +81,7 @@ require (
 	github.com/ugorji/go/codec v1.2.6 // indirect
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	go.opencensus.io v0.24.0 // indirect
+	golang.org/x/mobile v0.0.0-20210901025245-1fde1d6c3ca1 // indirect
 	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/net v0.25.0 // indirect
 	golang.org/x/oauth2 v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -470,6 +470,7 @@ github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oW
 github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=
 github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
+github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b h1:FosyBZYxY34Wul7O/MSKey3txpPYyCqVO5ZyceuQJEI=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
@@ -496,6 +497,7 @@ golang.org/x/crypto v0.24.0/go.mod h1:Z1PMYSOR5nyMcyAVAIQSKCDwalqy85Aqn1x3Ws4L5D
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
+golang.org/x/exp v0.0.0-20190731235908-ec7cb31e5a56/go.mod h1:JhuoJpWY28nO4Vef9tZUw9qufEGTyX1+7lmHxV5q5G4=
 golang.org/x/exp v0.0.0-20190829153037-c13cbed26979/go.mod h1:86+5VVa7VpoJ4kLfm080zCjGlMRFzhUhsZKEZO7MGek=
 golang.org/x/exp v0.0.0-20191030013958-a1ab85dbe136/go.mod h1:JXzH8nQsPlswgeRAPE3MuO9GYsAcnJvJ4vnMwN/5qkY=
 golang.org/x/exp v0.0.0-20191129062945-2f5052295587/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
@@ -516,11 +518,14 @@ golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRu
 golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
+golang.org/x/mobile v0.0.0-20210901025245-1fde1d6c3ca1 h1:t3ZHqovedSY8DEAUmZA99fPJhUhOb176PLACYA1sJ8Y=
+golang.org/x/mobile v0.0.0-20210901025245-1fde1d6c3ca1/go.mod h1:jFTmtFYCV0MFtXBU+J5V/+5AUeVS0ON/0WkE/KSrl6E=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.17.0 h1:zY54UmvipHiNd+pm+m0x9KhZ9hl1/7QNMyxXbc6ICqA=
 golang.org/x/mod v0.17.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -549,6 +554,7 @@ golang.org/x/net v0.0.0-20200222125558-5a598a2470a0/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200602114024-627f9648deb9/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.25.0 h1:d/OCCoBEUq33pjydKrGQhw7IlUPI2Oylr+8qLx49kac=
 golang.org/x/net v0.25.0/go.mod h1:JkAGAh7GEvH74S6FOH42FLoXpXbE/aqXSrIQjXgsiwM=
@@ -565,6 +571,7 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
 golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -605,8 +612,10 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
 golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -660,11 +669,13 @@ golang.org/x/tools v0.0.0-20200204074204-1cc6d1ef6c74/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200207183749-b753a1ba74fa/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200212150539-ea181f53ac56/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200224181240-023911ca70b2/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d h1:vU5i/LfpvrRCpgM/VPfJLg5KjxD3E+hfT1SH+d9zLwg=
 golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=


### PR DESCRIPTION
Use the boot command parser from Packer SDK, 

- add support for key combinaition, like `<leftCtrlOn>x<leftCtrlOff>`, 
- add support for more special keys, 
- fixes #171

Tested with an Alpine image and XCP-ng