### PR TITLE
Update faulty packer example template in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ The packer builder can be installed via `packer init` as long as the packer temp
 ```
 packer {
   required_plugins {
-   xenserver= {
+    xenserver= {
       version = ">= v0.6.0"
-      source = "github.com/vatesfr/packer-plugin-xenserver"
+      source = "github.com/vatesfr/xenserver"
     }
   }
 }


### PR DESCRIPTION
The current version had `source = "github.com/vatesfr/xenserver/packer-plugin-xenserver"` which produces the following `packer init` error:

```
Error: Failed to parse source

  on example.pkr.hcl line 3, in packer:
   3:     xenserver = {
   4:       version = ">= v0.6.0"
   5:       source = "github.com/vatesfr/packer-plugin-xenserver"
   6:     }

Plugin source has a type with the prefix "packer-plugin-", which isn't valid.
Although that prefix is often used in the names of version control repositories
for Packer plugins, plugin source strings should not include it.

Did you mean "xenserver"?
```

Renaming the source to `source = "github.com/vatesfr/xenserver"` and calling `packer init` again succeeded.