### PR TITLE
CI: Update goreleaser configuration and fix tag sorting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           go-version: "1.20"
       - name: Describe plugin
         id: plugin_describe
-        run: echo "::set-output name=api_version::$(go run . describe | jq -r '.api_version')"
+        run: echo "name=api_version::$(go run . describe | jq -r '.api_version')" >> $GITHUB_OUTPUT
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v5.0.0

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,9 +46,11 @@ builds:
         goarch: '386'
       - goos: linux
         goarch: amd64
+      - goos: windows
+        goarch: arm
     binary: '{{ .ProjectName }}_v{{ .Version }}_{{ .Env.API_VERSION }}_{{ .Os }}_{{ .Arch }}'
 archives:
-- format: zip
+- formats: [ 'zip' ]  
   files:
     - none*
   name_template: '{{ .ProjectName }}_v{{ .Version }}_{{ .Env.API_VERSION }}_{{ .Os }}_{{ .Arch }}'
@@ -72,3 +74,16 @@ release:
 
 changelog:
   disable: true
+
+git:
+  # What should be used to sort tags when gathering the current and previous
+  # tags if there are more than one tag in the same commit.
+  #
+  # See: https://git-scm.com/docs/git-tag#Documentation/git-tag.txt---sortltkeygt
+  #
+  # Default: '-version:refname'.
+  tag_sort: -version:creatordate
+
+  # What should be used to specify prerelease suffix while sorting tags when gathering
+  # the current and previous tags if there are more than one tag in the same commit.
+  prerelease_suffix: "-dev"


### PR DESCRIPTION
Update the goreleaser configuration to improve tag sorting 
Remove support for Windows arm (not arm64) platform (which is not supported). 
Adjust the output setting in the GitHub Actions workflow (the syntax used was deprecated).